### PR TITLE
What's new 2026-04-28

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,20 @@
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today
+## What's new today (2026-04-28)
 
-> _Sezione popolata automaticamente dalla [routine daily](./automations/daily-whats-new/) ogni mattina alle 07:00 Europe/Rome. Storico: [archive](./docs/whats-new-archive.md)._
+> _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-> **Status**: routine configurata, primo run al prossimo trigger. Fino al primo run questa sezione e' un placeholder.
-
----
+- **CLI v2.1.121** (28 apr 2026, 00:31 UTC): MCP `alwaysLoad`, `plugin prune`, PostToolUse hook output-replace per tutti i tool, fix memory leak immagini/`/usage`, fix scrollback duplication tmux/GNOME/Windows Terminal, Vertex AI mTLS. Fonte: [GitHub Releases](https://github.com/anthropics/claude-code/releases). Vedi [docs/19 § Fase 7](./docs/19-changelog.md).
+- **MCP `alwaysLoad`**: impostare `"alwaysLoad": true` su un server MCP forza il caricamento di tutti i suoi tool saltando il tool-search deferral — utile per server di uso continuo. Fonte: [changelog](https://code.claude.com/docs/en/changelog). Vedi [docs/10 § Configurazione](./docs/10-mcp.md).
+- **`claude plugin prune`**: nuovo comando che rimuove le dipendenze auto-installate da plugin rimossi; `plugin uninstall --prune` le elimina in cascata. Fonte: [GitHub Releases](https://github.com/anthropics/claude-code/releases). Vedi [docs/11 § Gestione plugin](./docs/11-plugins-marketplace.md).
+- **PostToolUse hooks output-replace**: `hookSpecificOutput.updatedToolOutput` ora funziona per tutti i tool (prima solo MCP), permettendo agli hook di sostituire qualsiasi output prima che Claude lo elabori. Fonte: [changelog](https://code.claude.com/docs/en/changelog). Vedi [docs/07 § PostToolUse](./docs/07-hooks.md).
+- **`/skills` search box**: aggiunta casella type-to-filter in `/skills` per trovare skill in liste lunghe senza scorrere. Fonte: [GitHub Releases](https://github.com/anthropics/claude-code/releases). Vedi [docs/09 § Bundled skills](./docs/09-skills.md).
+- **MCP auto-retry**: server MCP con errori transitori al boot ora ritenta automaticamente fino a 3 volte prima di fallire. Fonte: [changelog](https://code.claude.com/docs/en/changelog). Vedi [docs/10 § Configurazione](./docs/10-mcp.md).
+- **Fix memory leak**: risolto unbounded memory growth durante processing di immagini e leak ~2GB in `/usage` su sessioni lunghe. Fonte: [GitHub Releases](https://github.com/anthropics/claude-code/releases).
+- **Fix scrollback duplication**: eliminato il bug che duplicava output in tmux, GNOME Terminal e Windows Terminal in modalita' non-fullscreen. Fonte: [GitHub Releases](https://github.com/anthropics/claude-code/releases).
+- **Fix Bash tool**: risolto il caso in cui il Bash tool diventava inutilizzabile se la directory di avvio veniva eliminata a sessione gia' avviata. Fonte: [GitHub Releases](https://github.com/anthropics/claude-code/releases).
+- **Vertex AI mTLS + OpenTelemetry**: supporto X.509 Workload Identity Federation (mTLS ADC) per Vertex AI; LLM span OTel arricchiti con `stop_reason` e `gen_ai.response.finish_reasons`. Fonte: [GitHub Releases](https://github.com/anthropics/claude-code/releases).
 
 ---
 

--- a/docs/07-hooks.md
+++ b/docs/07-hooks.md
@@ -17,6 +17,8 @@ Gli hook permettono di intercettare deterministicamente il lifecycle di Claude C
 
 > Fonte: [`/en/hooks`](https://code.claude.com/docs/en/hooks).
 
+> **2026-04-28 (auto-update)**: v2.1.121 espande `PostToolUse` hooks — `hookSpecificOutput.updatedToolOutput` ora funziona per tutti i tool (in precedenza limitato ai tool MCP). Un hook `PostToolUse` puo' quindi intercettare e sostituire l'output di qualsiasi tool (Bash, Read, Edit, MCP, ecc.) prima che Claude lo elabori. Fonte: [GitHub Releases](https://github.com/anthropics/claude-code/releases). Vedi anche README "What's new today" del giorno.
+
 ---
 
 ## 7.1 Eventi supportati (28+)

--- a/docs/09-skills.md
+++ b/docs/09-skills.md
@@ -17,6 +17,8 @@ Skills = Markdown con YAML frontmatter che estendono Claude. Compatibile con [Ag
 
 > Fonte: [`/en/skills`](https://code.claude.com/docs/en/skills).
 
+> **2026-04-28 (auto-update)**: v2.1.121 aggiunge una search box type-to-filter in `/skills` — basta iniziare a digitare il nome per filtrare la lista senza scorrere, utile quando i plugin aggiungono decine di skill. Fonte: [GitHub Releases](https://github.com/anthropics/claude-code/releases). Vedi anche README "What's new today" del giorno.
+
 ---
 
 ## 9.1 Bundled skills (sempre disponibili)

--- a/docs/10-mcp.md
+++ b/docs/10-mcp.md
@@ -17,6 +17,8 @@ MCP e' il protocollo open per collegare LLM a tool esterni (DB, API, file, app).
 
 > Fonte: [`/en/mcp`](https://code.claude.com/docs/en/mcp).
 
+> **2026-04-28 (auto-update)**: v2.1.121 introduce due novita' per la configurazione MCP: (1) `alwaysLoad: true` su un server forza il caricamento immediato di tutti i suoi tool saltando il tool-search deferral — utile per server di uso continuo; (2) auto-retry fino a 3 volte su errori transitori al boot del server, eliminando restart manuali per flakiness temporanea. Fonte: [GitHub Releases](https://github.com/anthropics/claude-code/releases). Vedi anche README "What's new today" del giorno.
+
 ---
 
 ## 10.1 Configurazione base

--- a/docs/11-plugins-marketplace.md
+++ b/docs/11-plugins-marketplace.md
@@ -17,6 +17,8 @@ I plugin sono pacchetti che bundlano Skills, Subagents, Hooks, MCP server, LSP s
 
 > Fonti: [`/en/plugins`](https://code.claude.com/docs/en/plugins), [`/en/discover-plugins`](https://code.claude.com/docs/en/discover-plugins), [`/en/plugin-marketplaces`](https://code.claude.com/docs/en/plugin-marketplaces).
 
+> **2026-04-28 (auto-update)**: v2.1.121 aggiunge `claude plugin prune` — rimuove le dipendenze auto-installate da plugin non piu' presenti nell'installazione. Disponibile anche come flag: `claude plugin uninstall <nome> --prune` elimina il plugin e le sue dipendenze in cascata. Utile per chi ruota plugin frequentemente. Fonte: [GitHub Releases](https://github.com/anthropics/claude-code/releases). Vedi anche README "What's new today" del giorno.
+
 ---
 
 ## 11.1 Struttura di un plugin

--- a/docs/19-changelog.md
+++ b/docs/19-changelog.md
@@ -348,6 +348,23 @@ Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.
 - `--from-pr` accepts GitLab MR/Bitbucket PR/GHE (v2.1.119)
 - PostToolUse hooks include `duration_ms` (v2.1.119)
 
+### Week 17-18 (April 24–28, 2026, v2.1.120–v2.1.121)
+
+> **2026-04-28 (auto-update)**: v2.1.121 introduce MCP `alwaysLoad` (skip tool-search deferral), `claude plugin prune` per dipendenze orfane, PostToolUse hook output-replace per tutti i tool, `/skills` type-to-filter search box, MCP auto-retry (3x), fix memory leak immagini e `/usage`, fix scrollback duplication tmux/GNOME Terminal/Windows Terminal, Vertex AI mTLS ADC, OTel LLM span enrichment. Fonte: [GitHub Releases](https://github.com/anthropics/claude-code/releases). Vedi anche README "What's new today" del giorno.
+
+- **MCP `alwaysLoad`** (v2.1.121): `"alwaysLoad": true` in config server MCP — tutti i tool di quel server saltano il tool-search deferral
+- **`claude plugin prune`** (v2.1.121): rimuove dipendenze auto-installate da plugin rimossi; `--prune` flag su `plugin uninstall` per cascata
+- **PostToolUse hook output-replace per tutti i tool** (v2.1.121): `hookSpecificOutput.updatedToolOutput` precedentemente solo MCP, ora universale
+- **`/skills` type-to-filter** (v2.1.121): search box inline in `/skills`
+- **MCP auto-retry 3x** (v2.1.121): errori transitori al boot → retry automatico
+- **Fix memory leak** (v2.1.121): unbounded growth immagini + ~2GB leak `/usage` su sessioni lunghe
+- **Fix scrollback duplication** (v2.1.121): tmux, GNOME Terminal, Windows Terminal in non-fullscreen
+- **Fix Bash tool startup dir** (v2.1.121): tool non si blocca piu' se la working dir viene eliminata
+- **Vertex AI mTLS ADC** (v2.1.121): X.509 Workload Identity Federation
+- **OTel LLM span** (v2.1.121): `stop_reason`, `gen_ai.response.finish_reasons`, `user_system_prompt`
+- **`claude ultrareview [target]`** (v2.1.120, 24 apr): subcommand non-interattivo per CI/CD — [ClaudeCodeLog](https://x.com/ClaudeCodeLog/status/2047882231343878309)
+- **Windows: PowerShell default** (v2.1.120): Git Bash non piu' richiesto, PowerShell diventa shell di default
+
 ---
 
 ## 19.8 Post-mortem qualita' (apr 2026)
@@ -439,6 +456,7 @@ Vedi anche [@bcherny](https://x.com/bcherny/status/2047375800945783056).
 | 23 apr 2026 | v2.1.118 | Vim visual mode, custom themes, `mcp_tool` hooks |
 | 23 apr 2026 | v2.1.119 | `/config` persist, `prUrlTemplate`, `CLAUDE_CODE_HIDE_CWD` |
 | 24 apr 2026 | v2.1.120 | `claude ultrareview` non-interactive subcommand — [ClaudeCodeLog](https://x.com/ClaudeCodeLog/status/2047882231343878309) |
+| 28 apr 2026 | v2.1.121 | MCP `alwaysLoad`, `plugin prune`, PostToolUse hooks per tutti i tool, `/skills` search box, fix memory leak immagini/`/usage`, fix scrollback duplication tmux/GNOME/WinTerm, Vertex AI mTLS, OTel LLM span |
 
 ---
 


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily` ([automation README](../tree/main/automations/daily-whats-new)).

## Novita' coperte (CLI v2.1.121, 28 apr 2026)

1. **CLI v2.1.121** (release) — MCP `alwaysLoad`, `plugin prune`, PostToolUse hook output-replace universale, fix memory leak, Vertex AI mTLS
2. **MCP `alwaysLoad`** (feature) — skip tool-search deferral per server sempre attivi
3. **`claude plugin prune`** (feature) — rimozione dipendenze orfane plugin
4. **PostToolUse `hookSpecificOutput.updatedToolOutput`** (feature) — ora per tutti i tool, non solo MCP
5. **`/skills` type-to-filter** (feature) — search box inline nella lista skill
6. **MCP auto-retry 3x** (feature) — retry automatico su errori transitori al boot
7. **Fix memory leak immagini + `/usage`** (fix) — ~2GB su sessioni lunghe
8. **Fix scrollback duplication** (fix) — tmux / GNOME Terminal / Windows Terminal
9. **Fix Bash tool startup dir** (fix) — tool non si blocca se la working dir viene eliminata
10. **Vertex AI mTLS + OTel span** (feature) — X.509 WIF + `stop_reason` in LLM span

## File modificati

- `README.md` — sezione "What's new today (2026-04-28)" aggiornata (primo run, nessuna entry precedente da archiviare)
- `docs/19-changelog.md` — Week 17-18 section + riga v2.1.121 nella tabella 19.9
- `docs/07-hooks.md` — callout PostToolUse output-replace universale
- `docs/09-skills.md` — callout /skills search box
- `docs/10-mcp.md` — callout alwaysLoad + auto-retry
- `docs/11-plugins-marketplace.md` — callout plugin prune

## Verificare

- [ ] Sezione 'What's new today (2026-04-28)' nel README aggiornata con 10 voci
- [ ] Sezione precedente: era placeholder senza data, nessun archivio necessario (primo run)
- [ ] Callout aggiunti coerenti con i doc target
- [ ] Niente duplicati (nessuna entry precedente nell'archive)
- [ ] Tabella 19.9 in docs/19-changelog.md aggiornata con v2.1.121

## Note operative

- Fonti primarie consultate: GitHub Releases, code.claude.com/docs/en/changelog, code.claude.com/docs/en/whats-new
- anthropic.com/news: HTTP 403 (accesso negato) — nessun blog post rilevante perso: le release CLI non passano dal blog
- X.com (@bcherny, @ClaudeDevs, ecc.): nessun post specifico di oggi 28-04 trovato nelle ricerche
- Auto-merge non attivo per default. Mergiare manualmente se OK.

https://claude.ai/code/session_01J3kr1gqQscj5cCvhySBHWv

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3kr1gqQscj5cCvhySBHWv)_