### PR TITLE
What's new 2026-06-17

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,13 @@
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-> Nessuna novita' significativa nelle ultime 24 ore. Prossimo aggiornamento domani 07:00.
+- **CLI v2.1.179** (16 giu): fix mid-stream connection drops — risposta parziale ora preservata, spinner non si blocca su "running tool". Fonte: [GitHub Releases v2.1.179](https://github.com/anthropics/claude-code/releases/tag/v2.1.179). Vedi [docs/19-changelog.md](./docs/19-changelog.md).
+- **Fix WSL2 scroll** (v2.1.179, 16 giu): ripristinato scrolling con rotella del mouse in WSL2 su Windows Terminal e VS Code — regressione introdotta in v2.1.172. Fonte: [GitHub Releases v2.1.179](https://github.com/anthropics/claude-code/releases/tag/v2.1.179). Vedi [docs/19-changelog.md](./docs/19-changelog.md).
+- **Fix sandbox glob Linux** (v2.1.179, 16 giu): glob `denyRead`/`allowRead` su directory tree grandi non produce piu' descrizione del Bash tool enorme che rende la sessione inutilizzabile su Linux. Fonte: [GitHub Releases v2.1.179](https://github.com/anthropics/claude-code/releases/tag/v2.1.179). Vedi [docs/04-modalita-permessi.md](./docs/04-modalita-permessi.md).
+- **Fix sessioni remote background** (v2.1.179, 16 giu): i task in background non appaiono piu' bloccati come "still running" tra i turn nelle sessioni remote. Fonte: [GitHub Releases v2.1.179](https://github.com/anthropics/claude-code/releases/tag/v2.1.179). Vedi [docs/08-subagents.md](./docs/08-subagents.md).
+- **Fix UI subagent** (v2.1.179, 16 giu): Ctrl+O mostra ora la trascrizione del subagent quando lo si visualizza; click su prompt input restituisce il focus dal pannello subagent/footer; welcome screen mostra max 1 banner promo per sessione. Fonte: [GitHub Releases v2.1.179](https://github.com/anthropics/claude-code/releases/tag/v2.1.179). Vedi [docs/08-subagents.md](./docs/08-subagents.md).
+- **Fix feedback survey** (v2.1.179, 16 giu): il sondaggio di feedback non cattura piu' una risposta a singola cifra come rating sessione immediatamente dopo il completamento di un turno. Fonte: [GitHub Releases v2.1.179](https://github.com/anthropics/claude-code/releases/tag/v2.1.179).
+- **Miglioramento plugin loading** (v2.1.179, 16 giu): prestazioni di caricamento plugin migliorate nelle sessioni remote. Fonte: [GitHub Releases v2.1.179](https://github.com/anthropics/claude-code/releases/tag/v2.1.179). Vedi [docs/19-changelog.md](./docs/19-changelog.md).
 
 ---
 

--- a/docs/04-modalita-permessi.md
+++ b/docs/04-modalita-permessi.md
@@ -15,6 +15,8 @@ Claude Code ha 6 permission modes, una sandbox OS-level e un sistema di checkpoi
 
 **Per il deep-dive**: [04b — Authority model](./04b-authority-model.md) per il framework completo.
 
+> **2026-06-17 (auto-update)**: v2.1.179 corregge un bug critico su Linux — glob `denyRead`/`allowRead` su directory tree grandi produceva una descrizione del Bash tool enorme rendendo la sessione inutilizzabile. Fonte: [GitHub Releases v2.1.179](https://github.com/anthropics/claude-code/releases/tag/v2.1.179). Vedi anche README "What's new today" del giorno.
+
 ---
 
 ## 4.1 Permission modes

--- a/docs/08-subagents.md
+++ b/docs/08-subagents.md
@@ -17,6 +17,8 @@ Subagent = AI assistant specializzato con context window proprio, system prompt 
 
 > "Each subagent runs in its own context window with a custom system prompt, specific tool access, and independent permissions." — [`/en/sub-agents`](https://code.claude.com/docs/en/sub-agents)
 
+> **2026-06-17 (auto-update)**: v2.1.179 corregge due problemi nelle sessioni remote con subagent — i task in background non appaiono piu' bloccati come "still running" tra i turn; Ctrl+O mostra ora la trascrizione del subagent e il click su prompt input restituisce il focus dal pannello subagent/footer. Fonte: [GitHub Releases v2.1.179](https://github.com/anthropics/claude-code/releases/tag/v2.1.179). Vedi anche README "What's new today" del giorno.
+
 ---
 
 ## 8.1 Dove vivono

--- a/docs/19-changelog.md
+++ b/docs/19-changelog.md
@@ -517,8 +517,11 @@ Vedi anche [@bcherny](https://x.com/bcherny/status/2047375800945783056).
 | 13 giu 2026 | v2.1.177 | Aggiornamento CHANGELOG.md e feed.xml (maintenance). |
 | 15 giu 2026 | — | **Credito programmatico attivo**: il budget mensile dedicato per `claude -p`, Agent SDK, GitHub Actions e app terze parti entra in vigore per tutti i piani paid. Vedi [16.5](./16-headless-agent-sdk.md#crediti-mensili-per-uso-programmatico-attivi-dal-15-giu-2026). |
 | 15 giu 2026 | **v2.1.178** | **`Tool(param:value)` in permission rules**: sintassi per filtrare per parametro del tool — es. `Agent(model:opus)` in `deny` blocca sub-agenti Opus; wildcard `*` supportato. **Nested `.claude/` directory precedence**: skill/agenti/workflow/output-style nella `.claude/` piu' vicina alla working directory prevalgono; clash di nome risolti con prefisso `<dir>:<name>`. Auto mode: subagent spawns valutati dal classifier prima del lancio. `/doctor` rinnovato (layout flat, icone status, nomi comando evidenziati). |
+| 16 giu 2026 | **v2.1.179** | Fix mid-stream connection drops (risposta parziale preservata, spinner non bloccato su "running tool"); fix scroll rotella WSL2 su Windows Terminal/VS Code (regressione v2.1.172); fix glob `denyRead`/`allowRead` su directory tree grandi che rendeva descrizione Bash tool enorme e sessione inutilizzabile su Linux; fix feedback survey (risposta a singola cifra non catturata come rating sessione); fix welcome screen (max 1 banner promo per sessione); fix Ctrl+O transcript subagent; fix focus click su prompt input da pannello subagent/footer; fix background tasks remote bloccati come "still running" tra i turn; miglioramento plugin loading performance in sessioni remote. |
 
-<sub>Aggiornato 2026-06-16 via daily what's new. Fonte: [GitHub Releases v2.1.178](https://github.com/anthropics/claude-code/releases/tag/v2.1.178).</sub>
+> **2026-06-17 (auto-update)**: v2.1.179 porta 9 fix — i piu' impattanti: mid-stream connection drops preservano ora la risposta parziale; scroll WSL2 ripristinato (regressione 2.1.172); glob denyRead/allowRead non blocca piu' le sessioni Linux su repo grandi. Fonte: [GitHub Releases v2.1.179](https://github.com/anthropics/claude-code/releases/tag/v2.1.179). Vedi anche README "What's new today" del giorno.
+
+<sub>Aggiornato 2026-06-17 via daily what's new. Fonte: [GitHub Releases v2.1.179](https://github.com/anthropics/claude-code/releases/tag/v2.1.179).</sub>
 
 ---
 


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily` ([automation README](../tree/main/automations/daily-whats-new)).

## Novita' coperte (v2.1.179, 16 giu 2026)

- Fix mid-stream connection drops — risposta parziale preservata, spinner non bloccato
- Fix scroll rotella WSL2 su Windows Terminal e VS Code (regressione v2.1.172)
- Fix glob `denyRead`/`allowRead` su directory tree grandi (sessione inutilizzabile Linux)
- Fix task background sessioni remote bloccati come "still running"
- Fix UI subagent: Ctrl+O transcript, focus click su prompt input, welcome screen max 1 banner
- Fix feedback survey (risposta singola cifra non catturata come rating)
- Miglioramento plugin loading performance in sessioni remote

## File modificati

- `README.md` — sezione "What's new today (2026-06-17)" aggiornata (sostituisce "Nessuna novita'")
- `docs/19-changelog.md` — entry v2.1.179 aggiunta alla tabella + callout auto-update
- `docs/08-subagents.md` — callout fix remote session e UI subagent
- `docs/04-modalita-permessi.md` — callout fix sandbox glob Linux

## Errori durante il run

- WebFetch su `www.anthropic.com/news` ha restituito HTTP 403 — nessuna news Anthropic blog nelle 24h verificabile
- WebFetch diretti su profili `x.com` restituiscono HTTP 403 (paywall/auth) — post X team non verificabili via fetch diretto
- WebSearch su `site:x.com` non ha trovato post specifici del 17 giugno dai profili team Anthropic

## Verificare

- [ ] Sezione 'What's new today' nel README aggiornata
- [ ] Sezione precedente (2026-06-16) gia' archiviata in docs/whats-new-archive.md (nessuna azione necessaria)
- [ ] Callout aggiunti coerenti con i doc target
- [ ] Niente duplicati con ultime 7 entry archive

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4rAKF38ApiTw2z4v4hdW6)_