### PR TITLE
What's new 2026-06-18

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,27 @@
 # Claude Code — Guida (5 maggio 2026)
 
 > Reference completa di Claude Code (CLI, IDE, Web, Desktop, SDK) curata da [Boosha AI](https://boosha.it).
-> Ultimo aggiornamento: **17 giugno 2026, 07:00 CEST**.
-> Versione CLI di riferimento: **v2.1.179** · Modello default **Sonnet 4.6** · Premium **Fable 5 / Opus 4.8 + xhigh** (Max plan).
+> Ultimo aggiornamento: **18 giugno 2026, 07:00 CEST**.
+> Versione CLI di riferimento: **v2.1.181** · Modello default **Sonnet 4.6** · Premium **Fable 5 / Opus 4.8 + xhigh** (Max plan).
 
 > 🆕 **Novita' aprile 2026 (F4)**: integrato il case study **Kora team Every** (compound engineering applicato), **filosofia vibe-to-agentic**, **workflow operativi storici** (worktree script, Friday refactor, bug investigation), **Conductor + Ralph community pattern**. Nuova [Quick Start 60 min](./docs/QUICKSTART.md) + 8 [template `.claude/` per persona](./examples/personas/).
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-06-17)
+## What's new today (2026-06-18)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-> Nessuna novita' significativa nelle ultime 24 ore. Prossimo aggiornamento domani 07:00.
+- **CLI v2.1.181** (17 giu): introduce `/config key=value` per settare qualsiasi impostazione dal prompt in interattivo, `-p` e Remote Control; `sandbox.allowAppleEvents` per Apple Events su macOS sandboxed; upgrade Bun runtime a 1.4; 27+ bug fix. Fonte: [changelog](https://code.claude.com/docs/en/changelog). Vedi [docs/03 § Tabella](./docs/03-slash-commands.md) e [docs/19](./docs/19-changelog.md).
+- **`CLAUDE_CLIENT_PRESENCE_FILE`** (v2.1.181, 17 giu): nuova variabile d'ambiente — quando il file esiste, sopprime le notifiche push mobile mentre si e' alla macchina. Fonte: [changelog](https://code.claude.com/docs/en/changelog). Vedi [docs/02](./docs/02-cli-installazione.md).
+- **Subagent panel UX** (v2.1.181, 17 giu): auto-hide dopo 30s di inattivita', scroll limitato a 5 righe, keyboard hints nel footer. Fonte: [changelog](https://code.claude.com/docs/en/changelog). Vedi [docs/08](./docs/08-subagents.md).
+- **Fix critica: Write/Edit su network drive** (v2.1.181, 17 giu): risolto bug che produceva file da 0 byte o troncati su drive di rete e cartelle cloud-synced (Dropbox, OneDrive, ecc.). Fonte: [changelog](https://code.claude.com/docs/en/changelog).
+- **Fix: prompt caching su `ANTHROPIC_BASE_URL` custom e Foundry** (v2.1.181, 17 giu): risolto mancato caching prompt su endpoint non-Anthropic. Fonte: [changelog](https://code.claude.com/docs/en/changelog). Vedi [docs/18](./docs/18-settings-auth.md).
+- **Fix: macOS TUI freeze con Spotlight** (v2.1.181, 17 giu): risolto freeze all'avvio sessione quando Spotlight re-indicizza il disco. Fonte: [changelog](https://code.claude.com/docs/en/changelog).
+- **Fix: sessioni idle perdevano history** (v2.1.181, 17 giu): le sessioni inattive a lungo non perdono piu' la history durante la pulizia a 30 giorni dei transcript. Fonte: [changelog](https://code.claude.com/docs/en/changelog).
+- **Fix: sub-agenti foreground senza limite depth** (v2.1.181, 17 giu): risolto bug che permetteva a sub-agenti foreground di spawnare catene non delimitate; ora rispetta il limite 5 livelli. Fonte: [changelog](https://code.claude.com/docs/en/changelog). Vedi [docs/08](./docs/08-subagents.md).
+- **Fix: `/stats` date in timezone UTC-** (v2.1.181, 17 giu): date mostrate un giorno prima in timezone UTC-negative (EST, PST). Fonte: [changelog](https://code.claude.com/docs/en/changelog).
+- **Claude Design major update + `/design` in Claude Code** (17 giu): import design system da GitHub/file, editing diretto su canvas, riduzione token drastica; nuovo comando `/design` sincronizza progetti design da terminale senza screenshot o rebuild. Fonte: [@claudeai](https://x.com/claudeai/status/2067325887909884315) · [blog](https://claude.com/blog/claude-design-stays-on-brand-for-daily-work). Vedi [docs/03](./docs/03-slash-commands.md).
 
 ---
 

--- a/docs/02-cli-installazione.md
+++ b/docs/02-cli-installazione.md
@@ -5,6 +5,8 @@
 
 Reference completa CLI di Claude Code aggiornata a v2.1.119.
 
+> **2026-06-18 (auto-update)**: nuova env var `CLAUDE_CLIENT_PRESENCE_FILE` (v2.1.181) — quando il file specificato esiste sul filesystem, Claude Code sopprime le push notification mobile verso il telefono; rimuoverlo ripristina le notifiche. Utile in script di login/logout di scrivania. Fonte: [changelog](https://code.claude.com/docs/en/changelog). Vedi anche README "What's new today" del giorno.
+
 ## Cosa e' concettualmente
 
 > La CLI e' la **prima incarnazione** dell'agent harness Claude Code. Tutto cio' che vedi in VS Code, Desktop, Web e' uno strato di UX sopra lo stesso engine CLI. Imparare la CLI = imparare l'engine.

--- a/docs/03-slash-commands.md
+++ b/docs/03-slash-commands.md
@@ -5,6 +5,8 @@
 
 Riferimento completo dei comandi `/` built-in e bundled skills al v2.1.169. Type `/` in sessione per vederli filtrati. Convenzione: **[Skill]** = bundled skill (prompt-based, anche auto-invocabile da Claude); altri = built-in CLI.
 
+> **2026-06-18 (auto-update)**: `/config` supporta ora la sintassi `key=value` per settare qualsiasi impostazione direttamente dal prompt — funziona in interattivo, `-p` e Remote Control (es. `/config model=claude-fable-5`). Aggiunto il nuovo comando `/design` per creare, editare e sincronizzare progetti Claude Design senza lasciare il terminale (v2.1.181). Fonte: [changelog](https://code.claude.com/docs/en/changelog). Vedi anche README "What's new today" del giorno.
+
 ## Cosa e' concettualmente
 
 > Gli slash commands sono il **vocabolario condiviso** tra utente e agent. Sono shortcut a workflow ricorrenti: ognuno e' un'intent capture pre-codificato. I bundled skills (`/loop`, `/simplify`, `/batch`, `/debug`) sono skill markdown auto-installate; i built-in (`/plan`, `/compact`, `/effort`) sono comandi nativi del CLI.
@@ -33,12 +35,13 @@ Riferimento completo dei comandi `/` built-in e bundled skills al v2.1.169. Type
 | `/clear` (alias `/reset`, `/new`) | built-in | Nuova conversation, pregresso resta in `/resume` |
 | `/color [color\|default]` | built-in | Colore prompt bar (sync claude.ai con Remote Control) |
 | `/compact [instructions]` | built-in | Comprime context |
-| `/config` (alias `/settings`) | built-in | UI settings |
+| `/config [key=value]` (alias `/settings`) | built-in | UI settings; con `key=value` setta qualsiasi impostazione direttamente dal prompt (interattivo, `-p`, Remote Control) — es. `/config model=claude-fable-5` (da v2.1.181) |
 | `/context` | built-in | Visualizza uso context window |
 | `/copy [N]` | built-in | Copia ultima risposta (o N-esima); `w` per write to file |
 | `/cost` (alias `/usage`, `/stats`) | built-in | Costi e utilizzo |
 | `/debug [description]` | **Skill** | Debug logging mid-session |
 | `/deep-research <domanda>` | **Skill** | Workflow bundled di ricerca: fan-out di web search da piu' angolazioni, fetch e cross-check delle fonti, voto su ogni claim, report citato con i claim non verificati gia' filtrati (richiede il WebSearch tool). Vedi [24](./24-workflows.md) |
+| `/design [create\|edit\|sync]` | built-in | Crea, edita e sincronizza progetti Claude Design dal terminale senza screenshot o rebuild; hand-off bidirezionale Claude Code ↔ Claude Design (da v2.1.181) |
 | `/desktop` (alias `/app`) | built-in | Continua su Desktop app (macOS/Windows) |
 | `/diff` | built-in | Diff viewer interattivo (uncommitted + per-turn) |
 | `/doctor` | built-in | Diagnostica install + `f` per fix automatico |

--- a/docs/08-subagents.md
+++ b/docs/08-subagents.md
@@ -5,6 +5,8 @@
 
 Subagent = AI assistant specializzato con context window proprio, system prompt custom, tool e permessi indipendenti. Quando Claude trova task matchato dalla `description`, delega.
 
+> **2026-06-18 (auto-update)**: il subagent panel (visualizzazione sessioni sub-agente attive) si nasconde automaticamente dopo 30s di inattivita', ha uno scroll cap a 5 righe e mostra keyboard hints nel footer. Risolto anche il bug per cui i sub-agenti foreground potevano spawnare catene non delimitate ignorando il limite di 5 livelli (v2.1.181). Fonte: [changelog](https://code.claude.com/docs/en/changelog). Vedi anche README "What's new today" del giorno.
+
 ## Cosa e' concettualmente
 
 > I subagent sono **agent figli** spawnati dall'agent principale. Ognuno ha context window indipendente, tool subset, ev. modello diverso (Haiku per Explore = cheap+fast). Il main agent delega un task, riceve summary, continua. Pattern di "cognitive offloading": il main thread non si sporca con dettagli operativi.

--- a/docs/18-settings-auth.md
+++ b/docs/18-settings-auth.md
@@ -5,6 +5,8 @@
 
 Gerarchia settings, sintassi permessi, autenticazione (claude.ai, API key, Bedrock/Vertex/Foundry, OAuth).
 
+> **2026-06-18 (auto-update)**: aggiunto `sandbox.allowAppleEvents` (opt-in, macOS) per permettere ai comandi sandboxed di inviare Apple Events. Nuova env var `CLAUDE_CLIENT_PRESENCE_FILE`: quando il file esiste, sopprime le push notification mobile — utile se si e' gia' alla macchina. Risolto prompt caching su `ANTHROPIC_BASE_URL` custom e Foundry (v2.1.181). Fonte: [changelog](https://code.claude.com/docs/en/changelog). Vedi anche README "What's new today" del giorno.
+
 ## Cosa e' concettualmente
 
 > I settings sono la **configurazione dichiarativa dell'harness**. Cinque livelli di precedenza (managed > CLI args > local project > shared project > user) permettono di stratificare regole: enterprise impone policy, team condivide convenzioni, dev override locali. La sintassi permission e' Layer 1 dell'Authority.

--- a/docs/19-changelog.md
+++ b/docs/19-changelog.md
@@ -3,7 +3,7 @@
 > 📍 [README](../README.md) → [Riferimenti](../README.md#riferimenti) → **19 Changelog**
 > 📚 Riferimento · 🟢 Beginner-friendly
 
-Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (6 giugno 2026, v2.1.166). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
+Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (17 giugno 2026, v2.1.181). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
 
 ## Cosa e' concettualmente
 
@@ -517,8 +517,10 @@ Vedi anche [@bcherny](https://x.com/bcherny/status/2047375800945783056).
 | 13 giu 2026 | v2.1.177 | Aggiornamento CHANGELOG.md e feed.xml (maintenance). |
 | 15 giu 2026 | — | **Credito programmatico attivo**: il budget mensile dedicato per `claude -p`, Agent SDK, GitHub Actions e app terze parti entra in vigore per tutti i piani paid. Vedi [16.5](./16-headless-agent-sdk.md#crediti-mensili-per-uso-programmatico-attivi-dal-15-giu-2026). |
 | 15 giu 2026 | **v2.1.178** | **`Tool(param:value)` in permission rules**: sintassi per filtrare per parametro del tool — es. `Agent(model:opus)` in `deny` blocca sub-agenti Opus; wildcard `*` supportato. **Nested `.claude/` directory precedence**: skill/agenti/workflow/output-style nella `.claude/` piu' vicina alla working directory prevalgono; clash di nome risolti con prefisso `<dir>:<name>`. Auto mode: subagent spawns valutati dal classifier prima del lancio. `/doctor` rinnovato (layout flat, icone status, nomi comando evidenziati). |
+| 16 giu 2026 | v2.1.179 | Fix: drop connessione mid-stream (risposta parziale ora preservata); scrolling mouse-wheel WSL2 sotto Windows Terminal e VS Code; sandbox `denyRead`/`allowRead` glob su directory tree estesi su Linux; feedback survey catturava risposte a una cifra come rating sessione; banner promozionali multipli in welcome screen; Ctrl+O non mostrava transcript subagente; background tasks sessioni remote apparivano stuck; performance plugin loading in remote sessions. |
+| 17 giu 2026 | **v2.1.181** | **`/config key=value`**: sintassi diretta per settare qualsiasi impostazione dal prompt (interattivo, `-p`, Remote Control). **`sandbox.allowAppleEvents`**: opt-in per permettere Apple Events ai comandi sandboxed su macOS. **`CLAUDE_CLIENT_PRESENCE_FILE`**: nuova env var — quando il file esiste, sopprime push notification mobile (per evitare notifiche se gia' alla macchina). **Bun 1.4**: runtime bundled aggiornato. **Streaming paragrafi**: testo lungo in streaming riga per riga (non piu' attesa del primo line break). **Subagent panel**: auto-hide dopo 30s, scroll cap 5 righe, keyboard hints nel footer. **MCP OAuth**: browser page restyled, auto-close su successo. **Fullscreen URL**: richiede Cmd+click (macOS) / Ctrl+click per aprire. **27+ bug fix** tra cui: Write/Edit produceva file 0-byte o troncati su network drive e cloud-synced; TUI macOS freezava all'avvio con Spotlight in re-indicizzazione; sessioni idle perdevano history durante pulizia 30gg; sub-agenti foreground spawnano catene non delimitate (ora rispetta limite 5 livelli); `/recap` e fork usavano modello precedente dopo model switch; AWS credential refresh eseguiva refresh ogni minuto; prompt caching su `ANTHROPIC_BASE_URL` custom e Foundry; `/stats` mostrava date un giorno prima in timezone UTC-negative. |
 
-<sub>Aggiornato 2026-06-16 via daily what's new. Fonte: [GitHub Releases v2.1.178](https://github.com/anthropics/claude-code/releases/tag/v2.1.178).</sub>
+<sub>Aggiornato 2026-06-18 via daily what's new. Fonte: [changelog](https://code.claude.com/docs/en/changelog).</sub>
 
 ---
 

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -11,6 +11,12 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 ---
 
+## 2026-06-17
+
+> Nessuna novita' significativa nelle ultime 24 ore. (La release v2.1.181 del 17 giu e' stata registrata dal run del 18 giu — vedi README per dettagli.)
+
+---
+
 ## 2026-06-16
 
 - **`Tool(param:value)` nelle permission rules** (v2.1.178, 15 giu): le regole `allow`/`deny` in `settings.json` supportano ora la sintassi `Tool(param:value)` per filtrare in base ai parametri del tool — ad esempio `Agent(model:opus)` in `deny` blocca qualsiasi sub-agente che usa Opus, con supporto wildcard `*`. Fonte: [GitHub Releases v2.1.178](https://github.com/anthropics/claude-code/releases/tag/v2.1.178). Doc: [docs/18-settings-auth.md](./docs/18-settings-auth.md#183-permission-rule-syntax), [docs/19-changelog.md](./docs/19-changelog.md).


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily` ([automation README](../tree/main/automations/daily-whats-new)).

## Novita' coperte (10 voci)

**CLI v2.1.181 — 17 giugno 2026** (release principale):
- `/config key=value` — sintassi diretta per settare qualsiasi impostazione dal prompt
- `CLAUDE_CLIENT_PRESENCE_FILE` — nuova env var per sopprimere push notification mobile
- `sandbox.allowAppleEvents` — nuovo opt-in setting per macOS
- Bun runtime aggiornato a 1.4; streaming paragrafi riga per riga
- Subagent panel: auto-hide 30s, scroll cap 5 righe, keyboard hints
- 27+ bug fix: Write/Edit su network drive, TUI freeze macOS/Spotlight, prompt caching su base URL custom e Foundry, sessioni idle perdevano history, sub-agenti foreground ignoravano limite depth 5, `/stats` date in UTC-negative

**Claude Design major update — 17 giugno 2026**:
- Import design system da GitHub/file, editing su canvas, riduzione token
- Nuovo comando `/design` in Claude Code per sync bidirezionale senza screenshot

## File modificati

- `README.md` — sezione "What's new today" aggiornata a 2026-06-18, versione CLI a v2.1.181
- `docs/whats-new-archive.md` — archiviata sezione 2026-06-17
- `docs/19-changelog.md` — aggiunte versioni v2.1.179 e v2.1.181, aggiornato header
- `docs/03-slash-commands.md` — callout `/config key=value`, aggiunto `/design` in tabella
- `docs/08-subagents.md` — callout subagent panel UX + fix depth limit
- `docs/18-settings-auth.md` — callout `sandbox.allowAppleEvents`, `CLAUDE_CLIENT_PRESENCE_FILE`, fix prompt caching
- `docs/02-cli-installazione.md` — callout `CLAUDE_CLIENT_PRESENCE_FILE`

## Errori / note

- WebFetch su `anthropic.com/news`, `claude.com/blog`, `x.com` ha restituito HTTP 403 (paywall/auth). Dati integrati via WebSearch e WebFetch su `code.claude.com/docs/en/changelog` (fonte primaria, funzionante).
- Nessun post specifico @bcherny o @trq212 del 17-18 giu trovato nei risultati di ricerca.

Verificare:
- [ ] Sezione 'What's new today' nel README aggiornata a 2026-06-18
- [ ] Sezione precedente (2026-06-17) archiviata in docs/whats-new-archive.md
- [ ] Callout aggiunti coerenti con i doc target
- [ ] Niente duplicati con ultime 7 entry archive
- [ ] v2.1.181 aggiunta in docs/19-changelog.md

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYri61FGAmgn69dz9TXHzf)_