### PR TITLE
What's new 2026-06-21

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # Claude Code — Guida (5 maggio 2026)
 
 > Reference completa di Claude Code (CLI, IDE, Web, Desktop, SDK) curata da [Boosha AI](https://boosha.it).
-> Ultimo aggiornamento: **20 giugno 2026, 07:00 CEST**.
-> Versione CLI di riferimento: **v2.1.183** · Modello default **Sonnet 4.6** · Premium **Fable 5 / Opus 4.8 + xhigh** (Max plan).
+> Ultimo aggiornamento: **21 giugno 2026, 07:00 CEST**.
+> Versione CLI di riferimento: **v2.1.185** · Modello default **Sonnet 4.6** · Premium **Fable 5 / Opus 4.8 + xhigh** (Max plan).
 
 > 🆕 **Novita' aprile 2026 (F4)**: integrato il case study **Kora team Every** (compound engineering applicato), **filosofia vibe-to-agentic**, **workflow operativi storici** (worktree script, Friday refactor, bug investigation), **Conductor + Ralph community pattern**. Nuova [Quick Start 60 min](./docs/QUICKSTART.md) + 8 [template `.claude/` per persona](./examples/personas/).
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-06-20)
+## What's new today (2026-06-21)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-> Nessuna novita' significativa nelle ultime 24 ore. Prossimo aggiornamento domani 07:00.
+- **CLI v2.1.185** (20 giu): stream-stall hint API aggiornato in "Waiting for API response · will retry in …" e trigger da 10s a 20s — riduce i falsi allarmi durante operazioni lente. Fonte: [GitHub Releases v2.1.185](https://github.com/anthropics/claude-code/releases/tag/v2.1.185). Vedi [docs/19-changelog.md](./docs/19-changelog.md).
+- **@bcherny: Claude Code decifra la Lineare A** (20 giu): Boris Cherny mostra come Claude Code sia stato usato per decifrare la Lineare A, scrittura cretese di 3500 anni fa — caso d'uso non-coding inatteso. Fonte: [@bcherny](https://x.com/bcherny/status/2068064304503660962). Vedi n/a.
 
 ---
 

--- a/docs/19-changelog.md
+++ b/docs/19-changelog.md
@@ -3,7 +3,7 @@
 > 📍 [README](../README.md) → [Riferimenti](../README.md#riferimenti) → **19 Changelog**
 > 📚 Riferimento · 🟢 Beginner-friendly
 
-Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (17 giugno 2026, v2.1.181). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
+Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (20 giugno 2026, v2.1.185). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
 
 ## Cosa e' concettualmente
 
@@ -519,8 +519,11 @@ Vedi anche [@bcherny](https://x.com/bcherny/status/2047375800945783056).
 | 15 giu 2026 | **v2.1.178** | **`Tool(param:value)` in permission rules**: sintassi per filtrare per parametro del tool — es. `Agent(model:opus)` in `deny` blocca sub-agenti Opus; wildcard `*` supportato. **Nested `.claude/` directory precedence**: skill/agenti/workflow/output-style nella `.claude/` piu' vicina alla working directory prevalgono; clash di nome risolti con prefisso `<dir>:<name>`. Auto mode: subagent spawns valutati dal classifier prima del lancio. `/doctor` rinnovato (layout flat, icone status, nomi comando evidenziati). |
 | 17 giu 2026 | **v2.1.181** | **`/config key=value`**: imposta qualsiasi setting direttamente dal prompt senza modificare files (es. `/config thinking=false`) — funziona in interactive, `-p`, Remote Control. **`CLAUDE_CLIENT_PRESENCE_FILE`** (env var): sopprime push notification mobile finche' il file marker esiste. `sandbox.allowAppleEvents` opt-in per Apple Events su macOS. Streaming paragrafi lunghi riga-per-riga. Auto-retry su drop connessione mid-thinking. Subagent panel: idle auto-hide 30s, cap 5 righe con scroll hints. MCP OAuth page allineata allo stile CC. URL in fullscreen: richiede Cmd+click (macOS)/Ctrl+click. Bun runtime 1.4. |
 | 19 giu 2026 | **v2.1.183** | **Artifacts** (beta Team/Enterprise): pagine web interattive generate da sessione, condivisibili via link privato al team — PR walkthrough, dashboard di progetto, visualizzazioni codice — aggiornate in tempo reale. **`/design-sync [pull\|push]`**: sync bidirezionale Claude Code ↔ Claude Design (pull design system nel repo, push codice verso canvas Design). **Auto mode safety**: blocco automatico comandi distruttivi non richiesti (`git reset --hard`, `git checkout -- .`, `git clean -fd`, `git stash drop`, `git commit --amend`, `terraform/pulumi/cdk destroy`). **`/config --help`**: lista tutti gli shorthand disponibili. **`attribution.sessionUrl`**: omette link sessione claude.ai da commit e PR (web/Remote Control). Rimosso "setup issues" dallo startup — usa `/doctor`. |
+| 20 giu 2026 | v2.1.185 | Stream-stall hint aggiornato: messaggio cambia da "No response from API · Retrying in …" a "Waiting for API response · will retry in …"; trigger passa da 10s a 20s di silenzio. |
 
-<sub>Aggiornato 2026-06-19 via daily what's new. Fonte: [GitHub Releases v2.1.183](https://github.com/anthropics/claude-code/releases/tag/v2.1.183) · [@ClaudeDevs](https://x.com/ClaudeDevs/status/2067672094209675373).</sub>
+> **2026-06-21 (auto-update)**: v2.1.185 aggiorna il messaggio di stall API in "Waiting for API response · will retry in …" con trigger a 20s (prima 10s) — riduce i falsi allarmi durante operazioni lente. Fonte: [GitHub Releases v2.1.185](https://github.com/anthropics/claude-code/releases/tag/v2.1.185). Vedi anche README "What's new today" del giorno.
+
+<sub>Aggiornato 2026-06-21 via daily what's new. Fonte: [GitHub Releases v2.1.185](https://github.com/anthropics/claude-code/releases/tag/v2.1.185).</sub>
 
 ---
 

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -11,6 +11,12 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 ---
 
+## 2026-06-20
+
+> Nessuna novita' significativa nelle ultime 24 ore.
+
+---
+
 ## 2026-06-19
 
 - **Artifacts in Claude Code** (beta, Team & Enterprise, 19 giu): Claude trasforma il lavoro di sessione in pagine web condivise — PR walkthrough, dashboard di progetto — aggiornate in tempo reale mentre la sessione continua. Condivisibili via link privato al team. Fonte: [@ClaudeDevs](https://x.com/ClaudeDevs/status/2067672094209675373) · [@claudeai](https://x.com/claudeai/status/2067671912038240487). Doc: [docs/12-agent-teams.md](./docs/12-agent-teams.md), [docs/19-changelog.md](./docs/19-changelog.md).
@@ -199,12 +205,6 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 - **`/code-review --comment`** (v2.1.147, 21 mag): il flag `--comment` su `/code-review` pubblica i risultati della review come commenti inline direttamente su GitHub PR — chiude il loop tra analisi locale e feedback remoto senza uscire dal terminale. Fonte: [GitHub Releases v2.1.147](https://github.com/anthropics/claude-code/releases/tag/v2.1.147). Doc: [docs/03-slash-commands.md](./docs/03-slash-commands.md), [docs/19-changelog.md](./docs/19-changelog.md).
 - **Sessioni background pinnate** (v2.1.147, 21 mag): le sessioni pinnate con `Ctrl+T` in `claude agents` restano attive anche quando idle e si riavviano automaticamente per applicare gli aggiornamenti di Claude Code — utile per agent di lunga durata che non devono essere interrotti da inattivita'. Fonte: [GitHub Releases v2.1.147](https://github.com/anthropics/claude-code/releases/tag/v2.1.147). Doc: [docs/08-subagents.md](./docs/08-subagents.md), [docs/19-changelog.md](./docs/19-changelog.md).
-
----
-
-## 2026-05-21
-
-- **`/code-review` (ex `/simplify`)** (v2.1.146, 21 mag): `/simplify` rinominato `/code-review` con parametro effort opzionale (es. `/code-review high`) — il nuovo nome riflette meglio l'azione (3 review agent paralleli + apply fix) e allinea il comando all'interfaccia `/effort`. Il vecchio nome non e' piu' valido. Fonte: [GitHub Releases v2.1.146](https://github.com/anthropics/claude-code/releases/tag/v2.1.146). Doc: [docs/03-slash-commands.md](./docs/03-slash-commands.md), [docs/19-changelog.md](./docs/19-changelog.md).
 
 ---
 


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily`.

## Voci TLDR (2)

- **CLI v2.1.185** (20 giu 2026, ore 20:59): stream-stall hint API aggiornato — messaggio cambia in "Waiting for API response · will retry in …" e trigger passa da 10s a 20s di silenzio. Riduce i falsi allarmi durante operazioni API lente. Fonte: [GitHub Releases v2.1.185](https://github.com/anthropics/claude-code/releases/tag/v2.1.185).
- **@bcherny: Claude Code decifra la Lineare A** (20 giu 2026): Boris Cherny mostra come Claude Code sia stato usato per decifrare la Lineare A, scrittura cretese di 3500 anni fa. Fonte: [@bcherny](https://x.com/bcherny/status/2068064304503660962).

## File modificati

- `README.md` — sezione "What's new today" aggiornata a 2026-06-21; versione CLI di riferimento aggiornata a v2.1.185; data aggiornata
- `docs/whats-new-archive.md` — aggiunta entry 2026-06-20 (Nessuna novita'); rimossa entry 2026-05-21 (>30 giorni, fuori retention)
- `docs/19-changelog.md` — aggiunta riga v2.1.185 alla tabella; callout auto-update; header versione/data aggiornata

## Verificare

- [ ] Sezione 'What's new today' nel README aggiornata a 2026-06-21
- [ ] Sezione precedente (2026-06-20) archiviata in docs/whats-new-archive.md
- [ ] Callout aggiunto in docs/19-changelog.md coerente con il doc target
- [ ] Niente duplicati con le ultime 7 entry archive
- [ ] Entry 2026-05-21 rimossa dall'archive (retention 30gg)

## Note

Nessun errore durante il run. WebFetch su `www.anthropic.com/news` ha restituito HTTP 403; compensato con WebSearch. Tutti gli altri source accessibili correttamente.

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKmwULkxpqxPbTGYXwRMFg)_