### PR TITLE
What's new 2026-06-22

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-06-21)
+## What's new today (2026-06-22)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-> Nessuna novita' significativa nelle ultime 24 ore. Prossimo aggiornamento domani 07:00.
+- **[annuncio] Scadenza free access Fable 5 (OGGI)**: ultimo giorno di `claude-fable-5` incluso gratuitamente sui piani Pro/Max/Team/Enterprise. Da domani (23 giu) richiede usage credits ($10 input / $50 output per MTok). Nota: l'accesso e' sospeso dal 12 giu per direttiva US export control — la scadenza rimane in vigore per quando l'accesso sara' ripristinato. Fonte: [ghacks](https://www.ghacks.net/2026/06/10/anthropic-releases-claude-fable-5-to-pro-max-and-enterprise-users-free-until-june-22/). Vedi [docs/05 § 5.7](./docs/05-fast-mode-1m-context.md).
+- **[annuncio] Sospensione Fable 5 e Mythos 5 (dal 12 giu, ancora in corso)**: il governo USA ha emesso una direttiva di export control che sospende l'accesso mondiale a Fable 5 e Mythos 5 — inclusi utenti non-US e dipendenti Anthropic con cittadinanza straniera. Anthropic ha pubblicato un comunicato e sta lavorando per ripristinare l'accesso. Opus 4.7/4.8 e Sonnet 4.6 non sono interessati. Fonte: [Anthropic statement](https://www.anthropic.com/news/fable-mythos-access) · [@AnthropicAI](https://x.com/AnthropicAI/status/2065597531644743999). Vedi [docs/05 § 5.7](./docs/05-fast-mode-1m-context.md) e [docs/19](./docs/19-changelog.md).
+- **[fix] v2.1.185 (20 giu, non coperta ieri)**: stream-stall hint rinominato in "Waiting for API response · will retry in …" (era "No response from API · Retrying in …"), trigger ritardato da 10s a 20s — meno allarmistico per latenze API normali. Fonte: [GitHub Releases v2.1.185](https://github.com/anthropics/claude-code/releases/tag/v2.1.185). Vedi [docs/19](./docs/19-changelog.md).
 
 ---
 

--- a/docs/05-fast-mode-1m-context.md
+++ b/docs/05-fast-mode-1m-context.md
@@ -196,6 +196,8 @@ Con `/model claude-fable-5` il reasoning e' sempre on — `MAX_THINKING_TOKENS=0
 
 <sub>Aggiornato 2026-06-10 via daily what's new. Fonte: [GitHub Releases v2.1.170](https://github.com/anthropics/claude-code/releases/tag/v2.1.170) · [Anthropic docs](https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5).</sub>
 
+> **2026-06-22 (auto-update)**: accesso a Fable 5 sospeso dal 12 giu per direttiva US export control (national security) — Anthropic sta lavorando per ripristinare. Contemporaneamente, oggi (22 giu) scade il free access su piani Pro/Max/Team/Enterprise: da domani (23 giu) richiedera' usage credits ($10/$50 per MTok). Opus 4.7/4.8 e Sonnet 4.6 non sono interessati dalla sospensione. Fonte: [Anthropic statement](https://www.anthropic.com/news/fable-mythos-access). Vedi anche README "What's new today" del giorno.
+
 ---
 
 ## 5.5 Rapporto con il post-mortem aprile 2026

--- a/docs/19-changelog.md
+++ b/docs/19-changelog.md
@@ -3,7 +3,7 @@
 > 📍 [README](../README.md) → [Riferimenti](../README.md#riferimenti) → **19 Changelog**
 > 📚 Riferimento · 🟢 Beginner-friendly
 
-Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (17 giugno 2026, v2.1.181). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
+Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (20 giugno 2026, v2.1.185). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
 
 ## Cosa e' concettualmente
 
@@ -519,8 +519,12 @@ Vedi anche [@bcherny](https://x.com/bcherny/status/2047375800945783056).
 | 15 giu 2026 | **v2.1.178** | **`Tool(param:value)` in permission rules**: sintassi per filtrare per parametro del tool — es. `Agent(model:opus)` in `deny` blocca sub-agenti Opus; wildcard `*` supportato. **Nested `.claude/` directory precedence**: skill/agenti/workflow/output-style nella `.claude/` piu' vicina alla working directory prevalgono; clash di nome risolti con prefisso `<dir>:<name>`. Auto mode: subagent spawns valutati dal classifier prima del lancio. `/doctor` rinnovato (layout flat, icone status, nomi comando evidenziati). |
 | 17 giu 2026 | **v2.1.181** | **`/config key=value`**: imposta qualsiasi setting direttamente dal prompt senza modificare files (es. `/config thinking=false`) — funziona in interactive, `-p`, Remote Control. **`CLAUDE_CLIENT_PRESENCE_FILE`** (env var): sopprime push notification mobile finche' il file marker esiste. `sandbox.allowAppleEvents` opt-in per Apple Events su macOS. Streaming paragrafi lunghi riga-per-riga. Auto-retry su drop connessione mid-thinking. Subagent panel: idle auto-hide 30s, cap 5 righe con scroll hints. MCP OAuth page allineata allo stile CC. URL in fullscreen: richiede Cmd+click (macOS)/Ctrl+click. Bun runtime 1.4. |
 | 19 giu 2026 | **v2.1.183** | **Artifacts** (beta Team/Enterprise): pagine web interattive generate da sessione, condivisibili via link privato al team — PR walkthrough, dashboard di progetto, visualizzazioni codice — aggiornate in tempo reale. **`/design-sync [pull\|push]`**: sync bidirezionale Claude Code ↔ Claude Design (pull design system nel repo, push codice verso canvas Design). **Auto mode safety**: blocco automatico comandi distruttivi non richiesti (`git reset --hard`, `git checkout -- .`, `git clean -fd`, `git stash drop`, `git commit --amend`, `terraform/pulumi/cdk destroy`). **`/config --help`**: lista tutti gli shorthand disponibili. **`attribution.sessionUrl`**: omette link sessione claude.ai da commit e PR (web/Remote Control). Rimosso "setup issues" dallo startup — usa `/doctor`. |
+| 20 giu 2026 | **v2.1.185** | **Stream-stall hint aggiornato**: il messaggio di stallo ora legge "Waiting for API response · will retry in …" (era "No response from API · Retrying in …"); il trigger si attiva dopo 20s di silenzio invece di 10s — meno allarmistico per latenze API normali. |
+| 22 giu 2026 | — | **Scadenza free access Fable 5**: ultimo giorno di `claude-fable-5` incluso gratuitamente su piani Pro/Max/Team/Enterprise. Da domani (23 giu) richiede usage credits. Nota: accesso sospeso dal 12 giu per direttiva US export control — Anthropic lavora per ripristino. Fonte: [Anthropic statement](https://www.anthropic.com/news/fable-mythos-access). |
 
-<sub>Aggiornato 2026-06-19 via daily what's new. Fonte: [GitHub Releases v2.1.183](https://github.com/anthropics/claude-code/releases/tag/v2.1.183) · [@ClaudeDevs](https://x.com/ClaudeDevs/status/2067672094209675373).</sub>
+> **2026-06-22 (auto-update)**: v2.1.185 (20 giu) introduce stream-stall hint rinominato e trigger a 20s. Contestualmente, il governo USA ha emesso (12 giu) una direttiva di export control che sospende l'accesso mondiale a Fable 5 e Mythos 5 — ancora in vigore al 22 giu. Scade oggi (22 giu) anche il free access Fable 5 su piani subscription. Fonte: [GitHub Releases v2.1.185](https://github.com/anthropics/claude-code/releases/tag/v2.1.185) · [Anthropic statement](https://www.anthropic.com/news/fable-mythos-access). Vedi anche README "What's new today" del giorno.
+
+<sub>Aggiornato 2026-06-22 via daily what's new. Fonte: [GitHub Releases v2.1.185](https://github.com/anthropics/claude-code/releases/tag/v2.1.185) · [Anthropic statement](https://www.anthropic.com/news/fable-mythos-access).</sub>
 
 ---
 

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -11,6 +11,12 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 ---
 
+## 2026-06-21
+
+> Nessuna novita' significativa nelle ultime 24 ore.
+
+---
+
 ## 2026-06-20
 
 > Nessuna novita' significativa nelle ultime 24 ore.
@@ -198,13 +204,6 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 ## 2026-05-23
 
 > Nessuna novita' significativa nelle ultime 24 ore.
-
----
-
-## 2026-05-22
-
-- **`/code-review --comment`** (v2.1.147, 21 mag): il flag `--comment` su `/code-review` pubblica i risultati della review come commenti inline direttamente su GitHub PR — chiude il loop tra analisi locale e feedback remoto senza uscire dal terminale. Fonte: [GitHub Releases v2.1.147](https://github.com/anthropics/claude-code/releases/tag/v2.1.147). Doc: [docs/03-slash-commands.md](./docs/03-slash-commands.md), [docs/19-changelog.md](./docs/19-changelog.md).
-- **Sessioni background pinnate** (v2.1.147, 21 mag): le sessioni pinnate con `Ctrl+T` in `claude agents` restano attive anche quando idle e si riavviano automaticamente per applicare gli aggiornamenti di Claude Code — utile per agent di lunga durata che non devono essere interrotti da inattivita'. Fonte: [GitHub Releases v2.1.147](https://github.com/anthropics/claude-code/releases/tag/v2.1.147). Doc: [docs/08-subagents.md](./docs/08-subagents.md), [docs/19-changelog.md](./docs/19-changelog.md).
 
 ---
 


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily` ([automation README](../tree/main/automations/daily-whats-new)).

## Voci TLDR (3)

1. **[annuncio] Scadenza free access Fable 5 (OGGI 22 giu)**: ultimo giorno di `claude-fable-5` incluso gratuitamente sui piani Pro/Max/Team/Enterprise. Da domani (23 giu) richiede usage credits ($10/$50 per MTok). Nota: accesso sospeso dal 12 giu per export control USA.
2. **[annuncio] Sospensione Fable 5 e Mythos 5 (dal 12 giu, ancora in corso)**: direttiva US export control sospende accesso mondiale a Fable 5 e Mythos 5. Anthropic lavora per ripristino. Opus 4.7/4.8 e Sonnet 4.6 non interessati. Non era ancora coperta nell'archivio.
3. **[fix] v2.1.185 (20 giu, non coperta ieri)**: stream-stall hint rinominato e trigger ritardato da 10s a 20s.

## File modificati

- `README.md` — sezione "What's new today" aggiornata a 2026-06-22
- `docs/whats-new-archive.md` — archiviata sezione 2026-06-21; rimossa entry 2026-05-22 (retention 30 giorni)
- `docs/05-fast-mode-1m-context.md` — callout § 5.7 su sospensione + scadenza Fable 5
- `docs/19-changelog.md` — aggiunta riga v2.1.185 e nota sospensione Fable 5; titolo doc aggiornato a v2.1.185

## Fonti

- [Anthropic statement: Fable 5/Mythos 5 suspension](https://www.anthropic.com/news/fable-mythos-access)
- [GitHub Releases v2.1.185](https://github.com/anthropics/claude-code/releases/tag/v2.1.185)
- [gHacks: Fable 5 free access deadline](``https://www.ghacks.net/2026/06/10/anthropic-releases-claude-fable-5-to-pro-max-and-enterprise-users-free-until-june-22/``)

## Note

- WebFetch su anthropic.com/news: HTTP 403 (accesso negato) — compensato con WebSearch
- WebFetch su releasebot.io: HTTP 403 — compensato con WebSearch

Verificare:
- [ ] Sezione 'What's new today' nel README aggiornata
- [ ] Sezione precedente archiviata in docs/whats-new-archive.md
- [ ] Callout aggiunti coerenti con i doc target
- [ ] Niente duplicati con ultime 7 entry archive

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHDbLziGn923rSDMqqG3Pr)_