### PR TITLE
What's new 2026-06-29

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Claude Code — Guida (5 maggio 2026)
 
 > Reference completa di Claude Code (CLI, IDE, Web, Desktop, SDK) curata da [Boosha AI](https://boosha.it).
-> Ultimo aggiornamento: **28 giugno 2026, 07:00 CEST**.
+> Ultimo aggiornamento: **29 giugno 2026, 07:00 CEST**.
 > Versione CLI di riferimento: **v2.1.195** · Modello default **Sonnet 4.6** · Premium **Fable 5 / Opus 4.8 + xhigh** (Max plan).
 
 > 🆕 **Novita' aprile 2026 (F4)**: integrato il case study **Kora team Every** (compound engineering applicato), **filosofia vibe-to-agentic**, **workflow operativi storici** (worktree script, Friday refactor, bug investigation), **Conductor + Ralph community pattern**. Nuova [Quick Start 60 min](./docs/QUICKSTART.md) + 8 [template `.claude/` per persona](./examples/personas/).
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-06-28)
+## What's new today (2026-06-29)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-> Nessuna novita' significativa nelle ultime 24 ore. Prossimo aggiornamento domani 07:00.
+- **Post Boris Cherny — 5 archetipi di team nell'era AI** (29 giu): Boris Cherny (creator di Claude Code) descrive in un thread 5 archetipi emergenti nei team AI-native: Prototyper (genera idee, la maggior parte non shippano), Builder (porta in produzione), Sweeper (pulisce/ottimizza/unshipa), Grower (itera sul PMF), Maintainer (scala sistemi maturi). I ruoli non sono legati alla job function: designer e DS possono essere Builder quanto un engineer. Fonte: [@bcherny](https://x.com/bcherny/status/2071379474277613732). Dove in repo: n/a.
 
 ---
 

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -11,6 +11,12 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 ---
 
+## 2026-06-28
+
+> Nessuna novita' significativa nelle ultime 24 ore. Prossimo aggiornamento domani 07:00.
+
+---
+
 ## 2026-06-27
 
 > Nessuna novita' significativa nelle ultime 24 ore.
@@ -195,14 +201,6 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 - **Plugin auto-loading** (v2.1.157, 29 mag): i plugin in `.claude/skills/<nome>/` vengono caricati automaticamente senza passare per il marketplace — niente piu' `/plugin install` per plugin locali e custom. Fonte: [GitHub Releases v2.1.157](https://github.com/anthropics/claude-code/releases/tag/v2.1.157). Doc: [docs/11-plugins-marketplace.md](./docs/11-plugins-marketplace.md), [docs/09-skills.md](./docs/09-skills.md).
 - **`claude plugin init <name>`** (v2.1.157, 29 mag): nuovo comando CLI scaffolda un plugin in `.claude/skills/<nome>/` con struttura e manifest pronti — abbassa la barriera alla creazione di plugin locali senza configurazione manuale. Fonte: [GitHub Releases v2.1.157](https://github.com/anthropics/claude-code/releases/tag/v2.1.157). Doc: [docs/11-plugins-marketplace.md](./docs/11-plugins-marketplace.md).
 - **Campo `agent` in `settings.json` per dispatch** (v2.1.157, 29 mag): il campo `agent` viene ora rispettato per le sessioni dispatch con override per sessione via `--agent <name>` — permette di fissare l'agente di default senza modificare ogni invocazione. Fonte: [GitHub Releases v2.1.157](https://github.com/anthropics/claude-code/releases/tag/v2.1.157). Doc: [docs/08-subagents.md](./docs/08-subagents.md), [docs/18-settings-auth.md](./docs/18-settings-auth.md).
-
----
-
-## 2026-05-29
-
-- **Opus 4.8** (v2.1.154, 28 mag): nuovo modello flagship disponibile in Claude Code come default per task `xhigh`; Fast Mode su Opus 4.8 gira a 2.5x la velocita' standard a 2x il costo base. Fonte: [GitHub Releases v2.1.154](https://github.com/anthropics/claude-code/releases/tag/v2.1.154). Doc: [docs/05-fast-mode-1m-context.md](./docs/05-fast-mode-1m-context.md), [docs/19-changelog.md](./docs/19-changelog.md).
-- **`/workflows`** (v2.1.154, 28 mag): nuovo slash command per creare e orchestrare workflow dinamici con decine o centinaia di agenti background — descrivi il task, Claude genera il workflow ed esegue gli agenti in parallelo. Fonte: [GitHub Releases v2.1.154](https://github.com/anthropics/claude-code/releases/tag/v2.1.154). Doc: [docs/03-slash-commands.md](./docs/03-slash-commands.md), [docs/08-subagents.md](./docs/08-subagents.md), [docs/19-changelog.md](./docs/19-changelog.md).
-- **`! <command>` in `claude agents`** (v2.1.154, 28 mag): digitare `! <comando>` in Agent View esegue il comando shell direttamente in una sessione background — equivalente a `claude --bg --exec '<comando>'` senza uscire dall'interfaccia di gestione sessioni. Fonte: [GitHub Releases v2.1.154](https://github.com/anthropics/claude-code/releases/tag/v2.1.154). Doc: [docs/08-subagents.md](./docs/08-subagents.md).
 
 ---
 


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily` ([automation README](../tree/main/automations/daily-whats-new)).

## Contenuto

**1 voce TLDR generata** (giornata leggera — nessuna release CLI nelle ultime 24h):

- **Post Boris Cherny** (@bcherny, 29 giu): thread sui 5 archetipi di team nell'era AI applicati al Claude Code team — Prototyper, Builder, Sweeper, Grower, Maintainer. Fonte: https://x.com/bcherny/status/2071379474277613732

## Fonti consultate

| Fonte | Esito |
|---|---|
| code.claude.com/docs/en/changelog | OK — ultima release v2.1.195 del 26 giu, nessuna release nelle 24h |
| github.com/anthropics/claude-code/releases | OK — conferma nessuna release odierna |
| code.claude.com/docs/en/whats-new | OK — ultimo digest Week 26 (22–26 giu) |
| anthropic.com/news | HTTP 403 — non accessibile |
| x.com/bcherny | WebSearch OK — trovato thread archetipi da oggi |
| x.com/ClaudeDevs, claudeai, others | Nessun post odierno trovato |

## File modificati

- `README.md` — sezione "What's new today" aggiornata da 2026-06-28 a 2026-06-29; data "Ultimo aggiornamento" aggiornata
- `docs/whats-new-archive.md` — archiviata sezione 2026-06-28; rimossa entry 2026-05-29 (oltre il limite 30 giorni)

## Verificare

- [ ] Sezione 'What's new today' nel README aggiornata (data 2026-06-29)
- [ ] Sezione precedente (2026-06-28) archiviata in docs/whats-new-archive.md
- [ ] Niente duplicati con ultime 7 entry archive
- [ ] Entry 2026-05-29 rimossa (limite 30 giorni rispettato)

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2kwEYCLvzMTLixRuCQQK8)_