### PR TITLE
What's new 2026-07-03

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,27 @@
 # Claude Code — Guida (5 maggio 2026)
 
 > Reference completa di Claude Code (CLI, IDE, Web, Desktop, SDK) curata da [Boosha AI](https://boosha.it).
-> Ultimo aggiornamento: **2 luglio 2026, 07:00 CEST**.
-> Versione CLI di riferimento: **v2.1.197** · Modello default **Sonnet 5** · Premium **Fable 5 / Opus 4.8 + xhigh** (Max plan).
+> Ultimo aggiornamento: **3 luglio 2026, 07:00 CEST**.
+> Versione CLI di riferimento: **v2.1.199** · Modello default **Sonnet 5** · Premium **Fable 5 / Opus 4.8 + xhigh** (Max plan).
 
 > 🆕 **Novita' aprile 2026 (F4)**: integrato il case study **Kora team Every** (compound engineering applicato), **filosofia vibe-to-agentic**, **workflow operativi storici** (worktree script, Friday refactor, bug investigation), **Conductor + Ralph community pattern**. Nuova [Quick Start 60 min](./docs/QUICKSTART.md) + 8 [template `.claude/` per persona](./examples/personas/).
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-07-02)
+## What's new today (2026-07-03)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-- **Claude in Chrome GA** (v2.1.198, 1 lug): accesso browser-native alle sessioni e agli agenti Claude Code senza installazione aggiuntiva — la Chrome extension diventa surface di prima classe con Agent View completa. Fonte: [GitHub Releases v2.1.198](https://github.com/anthropics/claude-code/releases/tag/v2.1.198) · [@ClaudeCodeLog](https://x.com/ClaudeCodeLog/status/2072425697629343845). Doc: [docs/17-ide-surface.md](./docs/17-ide-surface.md), [docs/19-changelog.md](./docs/19-changelog.md).
-- **Background agents auto-delivery** (v2.1.198, 1 lug): gli agenti background al termine del lavoro in worktree eseguono automaticamente commit, push e aprono una draft PR — chiude il loop delivery senza intervento manuale. Fonte: [GitHub Releases v2.1.198](https://github.com/anthropics/claude-code/releases/tag/v2.1.198). Doc: [docs/08-subagents.md](./docs/08-subagents.md), [docs/19-changelog.md](./docs/19-changelog.md).
-- **`/dataviz` skill built-in** (v2.1.198, 1 lug): nuovo skill bundled per progettazione grafici, chart e dashboard — include validatore tavolozza colori e linee guida accessibilita' per output coerenti in light e dark mode. Fonte: [GitHub Releases v2.1.198](https://github.com/anthropics/claude-code/releases/tag/v2.1.198). Doc: [docs/09-skills.md](./docs/09-skills.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **CLI v2.1.199 — Stacked slash skills**: `/skill-a /skill-b do XYZ` carica fino a 5 skill in sequenza invece della sola prima — abilita pipeline di skill componibili. Fonte: [GitHub Releases v2.1.199](https://github.com/anthropics/claude-code/releases/tag/v2.1.199). Doc: [docs/09-skills.md](./docs/09-skills.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **CLI v2.1.199 — SSL/TLS fail-fast**: errori certificato (proxy TLS, cert scaduti, `NODE_EXTRA_CA_CERTS`) falliscono immediatamente con guida actionable invece di consumare i tentativi di retry. Fonte: [GitHub Releases v2.1.199](https://github.com/anthropics/claude-code/releases/tag/v2.1.199).
+- **CLI v2.1.199 — Streaming mid-error**: risposte parziali da API conservate in caso di errore mid-stream, con notice di incompletezza al posto del silenzio. Fonte: [GitHub Releases v2.1.199](https://github.com/anthropics/claude-code/releases/tag/v2.1.199).
+- **CLI v2.1.199 — Subagent reliability**: subagenti interrotti da rate limit o errori server restituiscono il lavoro parziale al parent agent anziche' perdere il risultato. Fonte: [GitHub Releases v2.1.199](https://github.com/anthropics/claude-code/releases/tag/v2.1.199). Doc: [docs/08-subagents.md](./docs/08-subagents.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **CLI v2.1.199 — Fix daemon Linux**: il daemon Linux non termina piu' i propri processi figli dopo uno shutdown non pulito. Fonte: [GitHub Releases v2.1.199](https://github.com/anthropics/claude-code/releases/tag/v2.1.199). Doc: [docs/08-subagents.md](./docs/08-subagents.md).
+- **CLI v2.1.199 — Fix macOS background**: risolto errore "Could not switch to audit session" per gli agenti background; fix race condition `claude stop` annullato da respawn automatico. Fonte: [GitHub Releases v2.1.199](https://github.com/anthropics/claude-code/releases/tag/v2.1.199). Doc: [docs/08-subagents.md](./docs/08-subagents.md).
+- **CLI v2.1.199 — Progress indicators**: indicatori di avanzamento non si bloccano piu' durante comandi lunghi; diagnostica helper su macchine con poca memoria disponibile. Fonte: [GitHub Releases v2.1.199](https://github.com/anthropics/claude-code/releases/tag/v2.1.199).
+- **CLI v2.1.199 — Retry watchdog 300x**: `CLAUDE_CODE_RETRY_WATCHDOG` alza il contatore retry default a 300 per errori transienti non-capacity (es. 429 rate limit). Fonte: [GitHub Releases v2.1.199](https://github.com/anthropics/claude-code/releases/tag/v2.1.199).
+- **CLI v2.1.199 — UI Agent View**: subagenti idle si comprimono in righe espandibili; PR link in `claude agents` in formato `#N` bare; fix comportamento `/model` e `/fast` a agent view aperta. Fonte: [GitHub Releases v2.1.199](https://github.com/anthropics/claude-code/releases/tag/v2.1.199).
+- **@ClaudeCodeLog** — preview v2.1.199 su X con tag `#cccnext` prima del rilascio: canale da seguire per annunci anticipati sulle prossime release. Fonte: [@ClaudeCodeLog](https://x.com/ClaudeCodeLog/status/2072737175402102981).
 
 ---
 

--- a/docs/08-subagents.md
+++ b/docs/08-subagents.md
@@ -178,6 +178,8 @@ Gli agenti background che lavorano in un git worktree possono ora chiudere il lo
 
 **Quando usarlo**: task delegati (code review fix, refactor specifici, generazione test) dove vuoi trovare una PR pronta senza dover poi fare commit manualmente.
 
+> **2026-07-03 (auto-update)**: reliability fix background agents (v2.1.199) — risolti tre problemi critici: (1) daemon Linux non termina piu' i processi figli dopo shutdown non pulito; (2) fix macOS "Could not switch to audit session" che impediva l'avvio degli agenti background; (3) fix race condition per cui `claude stop` veniva annullato dal respawn automatico. Subagenti interrotti da rate limit o errori server ora restituiscono il lavoro parziale al parent agent. Fonte: [GitHub Releases v2.1.199](https://github.com/anthropics/claude-code/releases/tag/v2.1.199). Vedi anche README "What's new today" del giorno.
+
 <sub>Aggiornato 2026-07-02 via daily what's new. Fonte: [GitHub Releases v2.1.198](https://github.com/anthropics/claude-code/releases/tag/v2.1.198).</sub>
 
 ---

--- a/docs/09-skills.md
+++ b/docs/09-skills.md
@@ -113,6 +113,8 @@ npm --version
 - Auto-compaction: re-attaches most recent invocation di ogni skill (5K token cap each, 25K total budget)
 - Per skill di grandi dimensioni dopo molte invocations, considera re-invoke dopo `/compact`
 
+> **2026-07-03 (auto-update)**: stacked slash-skill invocations (da v2.1.199) — e' ora possibile invocare fino a 5 skill in sequenza con `/skill-a /skill-b do XYZ`: tutte le skill elencate prima degli argomenti vengono caricate nell'ordine specificato, non solo la prima. Utile per pipeline di skill componibili (es. `/code-review /strict-mode review this PR`). Fonte: [GitHub Releases v2.1.199](https://github.com/anthropics/claude-code/releases/tag/v2.1.199). Vedi anche README "What's new today" del giorno.
+
 ---
 
 ## 9.5 Allowed-tools e Disallowed-tools

--- a/docs/19-changelog.md
+++ b/docs/19-changelog.md
@@ -3,7 +3,7 @@
 > 📍 [README](../README.md) → [Riferimenti](../README.md#riferimenti) → **19 Changelog**
 > 📚 Riferimento · 🟢 Beginner-friendly
 
-Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (30 giugno 2026, v2.1.197). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
+Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (2 luglio 2026, v2.1.199). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
 
 ## Cosa e' concettualmente
 
@@ -530,8 +530,9 @@ Vedi anche [@bcherny](https://x.com/bcherny/status/2047375800945783056).
 | 29 giu 2026 | **v2.1.196** | **Modello default organizzativo**: admin configurano il modello predefinito per tutta l'org dalla console (mostrato come "Org default" o "Role default" in `/model`). **Sicurezza MCP**: `claude mcp list`/`get` non avvia piu' server da `.mcp.json` auto-approvati via settings committati; workspace non affidabili mostrano `⏠ Pending approval`. **Background jobs sopravvivono a restart sessione** (incluso Windows: shell background trasferite anziche' terminate). `/code-review`: 5 finder consolidati in 1, -25% utilizzo token. Streaming idle watchdog abilitato di default per tutti i provider (ritenta dopo 5 min senza risposta; `CLAUDE_ENABLE_STREAM_WATCHDOG=0` per disabilitare). Nomi sessioni leggibili all'avvio. File allegati in chat cliccabili (Cmd/Ctrl-click rivela in Finder/Explorer). Auto-resume sessioni Remote interrotte da restart server. |
 | 30 giu 2026 | **v2.1.197** | **Claude Sonnet 5 — nuovo modello default**: `claude-sonnet-5` sostituisce Sonnet 4.6 come modello di default per Free e Pro. Context window 1M token nativa, 128k output max. Pricing promozionale $2/$10 per MTok fino al 31 ago 2026 (poi $3/$15). Performance: 43.7% Pass@1 su APEX-SWE (#3 dopo Fable 5 e Opus 4.8). |
 | 1 lug 2026 | **v2.1.198** | **Claude in Chrome GA**: accesso browser-native alle sessioni e agli agenti senza installazione aggiuntiva. **Background agents auto-delivery**: al termine del lavoro in worktree, commit + push + apertura draft PR automatici. **`/dataviz` skill built-in**: progettazione grafici e dashboard con validatore tavolozza colori e linee guida accessibilita'. Hook `Notification`: sottotipi `agent_needs_input` e `agent_completed`. Explore agent eredita il modello della sessione principale. Extended thinking ereditato da subagent e compaction. |
+| 2 lug 2026 | **v2.1.199** | **Stacked slash skills**: `/skill-a /skill-b do XYZ` carica fino a 5 skill in sequenza (non solo la prima). **SSL/TLS fail-fast**: errori certificato (proxy TLS, cert scaduti, `NODE_EXTRA_CA_CERTS`) falliscono immediatamente con guida actionable. **Streaming mid-error**: risposte parziali conservate con notice di incompletezza. **Subagent reliability**: subagenti interrotti da rate limit/errori server restituiscono lavoro parziale al parent. **Fix daemon Linux**: no piu' auto-kill processi figli dopo shutdown non pulito. **Fix macOS background**: risolto "Could not switch to audit session"; fix race `claude stop` da respawn. **Progress indicators**: non si bloccano piu' su comandi lunghi; diagnostica su macchine memory-starved. **`CLAUDE_CODE_RETRY_WATCHDOG` → 300**: retry default per errori transienti non-capacity. **UI Agent View**: idle subagent collapse in righe espandibili; PR link formato `#N`. |
 
-<sub>Aggiornato 2026-07-02 via daily what's new. Fonte: [GitHub Releases v2.1.198](https://github.com/anthropics/claude-code/releases/tag/v2.1.198).</sub>
+<sub>Aggiornato 2026-07-03 via daily what's new. Fonte: [GitHub Releases v2.1.199](https://github.com/anthropics/claude-code/releases/tag/v2.1.199).</sub>
 
 ---
 

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -11,6 +11,14 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 ---
 
+## 2026-07-02
+
+- **Claude in Chrome GA** (v2.1.198, 1 lug): accesso browser-native alle sessioni e agli agenti Claude Code senza installazione aggiuntiva — la Chrome extension diventa surface di prima classe con Agent View completa. Fonte: [GitHub Releases v2.1.198](https://github.com/anthropics/claude-code/releases/tag/v2.1.198) · [@ClaudeCodeLog](https://x.com/ClaudeCodeLog/status/2072425697629343845). Doc: [docs/17-ide-surface.md](./docs/17-ide-surface.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **Background agents auto-delivery** (v2.1.198, 1 lug): gli agenti background al termine del lavoro in worktree eseguono automaticamente commit, push e aprono una draft PR — chiude il loop delivery senza intervento manuale. Fonte: [GitHub Releases v2.1.198](https://github.com/anthropics/claude-code/releases/tag/v2.1.198). Doc: [docs/08-subagents.md](./docs/08-subagents.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **`/dataviz` skill built-in** (v2.1.198, 1 lug): nuovo skill bundled per progettazione grafici, chart e dashboard — include validatore tavolozza colori e linee guida accessibilita' per output coerenti in light e dark mode. Fonte: [GitHub Releases v2.1.198](https://github.com/anthropics/claude-code/releases/tag/v2.1.198). Doc: [docs/09-skills.md](./docs/09-skills.md), [docs/19-changelog.md](./docs/19-changelog.md).
+
+---
+
 ## 2026-07-01
 
 - **Claude Sonnet 5 — nuovo modello default** (v2.1.197, 30 giu): `claude-sonnet-5` sostituisce Sonnet 4.6 come modello di default in Claude Code per Free e Pro. Finestra di contesto nativa da 1M token, 128k output max. Pricing promozionale $2/$10 per MTok fino al 31 agosto (poi $3/$15). Performance: #3 su APEX-SWE (43.7% Pass@1). Aggiornare con `claude update`. Fonte: [@ClaudeDevs](https://x.com/ClaudeDevs/status/2072018504392601762). Doc: [docs/05-fast-mode-1m-context.md](./docs/05-fast-mode-1m-context.md), [docs/19-changelog.md](./docs/19-changelog.md).


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily`.

## Novita' del giorno (10 voci)

Release **v2.1.199** (2 lug 2026, 23:35 UTC) — unica release nelle ultime 24 ore:

1. **Stacked slash skills**: `/skill-a /skill-b do XYZ` carica fino a 5 skill in sequenza
2. **SSL/TLS fail-fast**: errori certificato falliscono subito con guida actionable
3. **Streaming mid-error**: risposte parziali conservate con notice di incompletezza
4. **Subagent reliability**: subagenti interrotti da rate limit restituiscono lavoro parziale al parent
5. **Fix daemon Linux**: no piu' auto-kill processi figli dopo shutdown non pulito
6. **Fix macOS background**: risolto "Could not switch to audit session" + fix `claude stop` race
7. **Progress indicators**: non si bloccano piu' durante comandi lunghi
8. **Retry watchdog 300x**: `CLAUDE_CODE_RETRY_WATCHDOG` → 300 retry default per errori transienti
9. **UI Agent View**: idle subagent collapse, PR link formato `#N`, fix `/model`/`/fast`
10. **@ClaudeCodeLog** — preview #cccnext prima del rilascio ufficiale

## File modificati

- `README.md` — sezione "What's new today" aggiornata a 2026-07-03 + metadata versione v2.1.199
- `docs/whats-new-archive.md` — sezione 2026-07-02 archiviata in cima
- `docs/19-changelog.md` — riga v2.1.199 aggiunta alla tabella + header versione aggiornato
- `docs/09-skills.md` — callout stacked slash-skill invocations (§9.4)
- `docs/08-subagents.md` — callout reliability fix background agents (§8.6c)

## Verificare

- [ ] Sezione 'What's new today' nel README aggiornata al 2026-07-03
- [ ] Sezione 2026-07-02 archiviata in docs/whats-new-archive.md
- [ ] Callout aggiunti coerenti con i doc target
- [ ] Niente duplicati con ultime 7 entry archive

Auto-merge non attivo per default. Mergiare manualmente se OK.

## Fonti

- [GitHub Releases v2.1.199](https://github.com/anthropics/claude-code/releases/tag/v2.1.199)
- [@ClaudeCodeLog](https://x.com/ClaudeCodeLog/status/2072737175402102981)

## Note

WebFetch su `anthropic.com/news` ha restituito HTTP 403 (Cloudflare). Le altre fonti hanno risposto correttamente. Blog Anthropic non incluso per indisponibilita' della fonte; nessun annuncio rilevante trovato via WebSearch alternativo.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBi3NjKs3Q1gaATCEMfmoS)_