### PR TITLE
What's new 2026-07-06

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-07-05)
+## What's new today (2026-07-06)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -9,6 +9,12 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 **Politica di retention**: ultimi 30 giorni. Le entry piu' vecchie sono cancellate (per evitare crescita illimitata del file). La storia completa resta comunque tracciabile via `git log README.md`.
 
+## 2026-07-05
+
+> Nessuna novita' significativa nelle ultime 24 ore.
+
+---
+
 ## 2026-07-04
 
 - **Permission mode default → `manual`** (v2.1.200, 3 lug): il permission mode attivo all'avvio e' rinominato da `default` a `manual` in CLI, VS Code e JetBrains — comportamento invariato (solo letture auto-approvate), label piu' descrittiva. Contestualmente `AskUserQuestion` non auto-continua piu' dopo timeout idle; per riattivarla: `/config`. Fonte: [GitHub Releases v2.1.200](https://github.com/anthropics/claude-code/releases/tag/v2.1.200) · [@ClaudeCodeLog](https://x.com/ClaudeCodeLog/status/2073091434123591872). Doc: [docs/04-modalita-permessi.md](./docs/04-modalita-permessi.md), [docs/19-changelog.md](./docs/19-changelog.md).
@@ -195,12 +201,6 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 - **`fallbackModel` setting** (v2.1.166, 6 giu): il campo `fallbackModel` in `settings.json` configura fino a 3 modelli di fallback provati in sequenza quando il primario e' sovraccarico o non disponibile; `--fallback-model` funziona ora anche nelle sessioni interattive (in precedenza solo in modalita' `-p`). Fonte: [GitHub Releases v2.1.166](https://github.com/anthropics/claude-code/releases/tag/v2.1.166). Doc: [docs/18-settings-auth.md](./docs/18-settings-auth.md), [docs/19-changelog.md](./docs/19-changelog.md).
 - **Thinking Token Control** (v2.1.166, 6 giu): `MAX_THINKING_TOKENS=0`, `--thinking disabled` e il toggle per-modello disattivano il thinking su modelli che lo abilitano di default via Claude API — per output piu' rapidi o deterministici nei workflow API. Fonte: [GitHub Releases v2.1.166](https://github.com/anthropics/claude-code/releases/tag/v2.1.166). Doc: [docs/05-fast-mode-1m-context.md](./docs/05-fast-mode-1m-context.md), [docs/18-settings-auth.md](./docs/18-settings-auth.md).
 - **Cross-session messaging hardening** (v2.1.166, 6 giu): i messaggi inoltrati via `SendMessage` da altre sessioni Claude non portano piu' l'autorita' dell'utente; i ricevitori rifiutano le richieste di permesso inoltrate e auto mode le blocca — rafforza la sicurezza nei workflow multi-agente con `SendMessage`. Fonte: [GitHub Releases v2.1.166](https://github.com/anthropics/claude-code/releases/tag/v2.1.166). Doc: [docs/08-subagents.md](./docs/08-subagents.md).
-
----
-
-## 2026-06-05
-
-> Nessuna novita' significativa nelle ultime 24 ore.
 
 ---
 


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily` ([automation README](../tree/main/automations/daily-whats-new)).

**Risultato ricerca**: nessuna novita' significativa nelle ultime 24 ore (5-6 luglio 2026).
- Ultimo GitHub Release: v2.1.201 (3 luglio) — gia' coperto nell'archive 2026-07-04
- Ultima entry `whats-new`: Week 26 (22-26 giugno) — nessuna entry Week 27 ancora pubblicata
- X team Anthropic: nessun post del 5-6 luglio identificato
- Anthropic news: HTTP 403 (accesso negato dalla routine)

**Fonti controllate**:
- [x] code.claude.com/docs/en/changelog (ok)
- [x] github.com/anthropics/claude-code/releases (ok)
- [x] code.claude.com/docs/en/whats-new (ok)
- [ ] anthropic.com/news (HTTP 403)
- [x] X @bcherny, @ClaudeDevs, @claudeai, @ClaudeCodeLog, @trq212, @noahzweben via WebSearch (ok, nessun post 5-6 lug)

Verificare:
- [ ] Sezione 'What's new today' nel README aggiornata (2026-07-05 → 2026-07-06)
- [ ] Sezione precedente (2026-07-05) archiviata in docs/whats-new-archive.md
- [ ] Entry piu' vecchia (2026-06-05) rimossa per policy 30 giorni
- [ ] Niente duplicati con ultime 7 entry archive

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiekszQhca3iZZ2NgCwknp)_