### PR TITLE
What's new 2026-07-07

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-07-06)
+## What's new today (2026-07-07)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-> Nessuna novita' significativa nelle ultime 24 ore. Prossimo aggiornamento domani 07:00.
+- **CLI v2.1.202** (6 lug): nuova setting **"Dynamic workflow size"** in `/config` — regola quanto grandi Claude tende a fare i dynamic workflow (small/medium/large agent count, solo advisory, non un cap imposto). Aggiunti attributi OTel `workflow.run_id`/`workflow.name` per ricostruire l'attivita' di un run dai dati di telemetria. Fonte: [GitHub Releases v2.1.202](https://github.com/anthropics/claude-code/releases/tag/v2.1.202). Vedi [docs/24 § Workflows](./docs/24-workflows.md) e [docs/19 § Changelog](./docs/19-changelog.md).
+- **CLI v2.1.202**: `/review <pr>` torna a essere una **review veloce single-pass**; per la review multi-agente a effort configurabile resta `/code-review <level> <pr#>`. Fonte: [GitHub Releases v2.1.202](https://github.com/anthropics/claude-code/releases/tag/v2.1.202). Vedi [docs/03 § Tabella completa](./docs/03-slash-commands.md).
+- **CLI v2.1.202**: bundle di 15+ fix di affidabilita' — crash Ctrl+R history search, `/rename` su sessioni background revertito dopo restart, comandi/allegati Remote Control persi, resume lento con molti git worktree, retry illimitato voice dictation su errore microfono, skill ricaricate che duplicavano le istruzioni in context, download installer che abortivano su drop di rete. Fonte: [GitHub Releases v2.1.202](https://github.com/anthropics/claude-code/releases/tag/v2.1.202). Vedi [docs/19 § Changelog](./docs/19-changelog.md).
 
 ---
 

--- a/docs/03-slash-commands.md
+++ b/docs/03-slash-commands.md
@@ -111,6 +111,8 @@ Riferimento completo dei comandi `/` built-in e bundled skills al v2.1.183. Type
 
 <sub>Aggiornato 2026-06-19 via daily what's new. Fonte: [GitHub Releases v2.1.183](https://github.com/anthropics/claude-code/releases/tag/v2.1.183) · [@ClaudeDevs](https://x.com/ClaudeDevs/status/2067391951725629941).</sub>
 
+> **2026-07-07 (auto-update)**: `/review [PR]` (v2.1.202, 6 lug) torna a essere una review veloce single-pass; per la review multi-agente con effort configurabile usa `/code-review <level> [PR]`. Fonte: [GitHub Releases v2.1.202](https://github.com/anthropics/claude-code/releases/tag/v2.1.202). Vedi anche README "What's new today" del giorno.
+
 ---
 
 ## 3.2 Comandi rimossi / migrati

--- a/docs/19-changelog.md
+++ b/docs/19-changelog.md
@@ -534,8 +534,9 @@ Vedi anche [@bcherny](https://x.com/bcherny/status/2047375800945783056).
 | 2 lug 2026 | — | **Artifacts esteso a Pro e Max**: Artifacts in Claude Code (pagine web condivisibili da sessione) ora disponibili su Pro e Max — prima solo Team/Enterprise. [@ClaudeDevs](https://x.com/ClaudeDevs/status/2072770790114914317). |
 | 3 lug 2026 | **v2.1.200** | **Permission mode rinominato `manual`**: il mode `default` diventa `manual` in CLI, VS Code e JetBrains (comportamento invariato — solo reads auto). `AskUserQuestion` no auto-continue by default; opt-in via `/config`. Accessibilita': screen reader migliorato, nested tables come "Header: value". Fix: sessioni background interrotte da sleep/wake, subagent tagliati da rate limit, flicker tmux 3.4+. |
 | 3 lug 2026 | v2.1.201 | Fix: sessioni Sonnet 5 non usano piu' mid-conversation system role per harness reminders. |
+| 6 lug 2026 | **v2.1.202** | **"Dynamic workflow size" in `/config`**: regola quanto grandi Claude tende a fare i workflow dinamici (small/medium/large agent count, solo advisory). Attributi OTel `workflow.run_id`/`workflow.name` per telemetria workflow. **`/review <pr>` torna single-pass veloce**; `/code-review <level> <pr#>` resta il comando per la review multi-agente a effort configurabile. 15+ fix di affidabilita': crash Ctrl+R history search, `/rename` su sessioni background revertito dopo restart, handshake mTLS transitori durante rotazione certificati, comandi e allegati Remote Control persi, resume lento/memory-heavy con molti git worktree, retry illimitato voice dictation su errore microfono, skill ricaricate che duplicavano le istruzioni in context, download installer/updater che abortivano su drop di rete. |
 
-<sub>Aggiornato 2026-07-04 via daily what's new. Fonte: [GitHub Releases v2.1.200](https://github.com/anthropics/claude-code/releases/tag/v2.1.200).</sub>
+<sub>Aggiornato 2026-07-07 via daily what's new. Fonte: [GitHub Releases v2.1.202](https://github.com/anthropics/claude-code/releases/tag/v2.1.202).</sub>
 
 ---
 

--- a/docs/24-workflows.md
+++ b/docs/24-workflows.md
@@ -18,6 +18,8 @@ Lanciati il **28 maggio 2026** con Opus 4.8, in **research preview**. Richiedono
 
 > Fonti: [`/en/workflows`](https://code.claude.com/docs/en/workflows), [blog Anthropic — Introducing dynamic workflows](https://claude.com/blog/introducing-dynamic-workflows-in-claude-code), [changelog v2.1.154](https://code.claude.com/docs/en/changelog).
 
+> **2026-07-07 (auto-update)**: nuova setting "Dynamic workflow size" in `/config` (v2.1.202, 6 lug) regola quanto grandi Claude tende a fare i workflow (small/medium/large agent count) — linea guida advisory, non un cap imposto. Aggiunti anche attributi OTel `workflow.run_id`/`workflow.name` per ricostruire l'attivita' di un run dai dati di telemetria. Fonte: [GitHub Releases v2.1.202](https://github.com/anthropics/claude-code/releases/tag/v2.1.202). Vedi anche README "What's new today" del giorno.
+
 ---
 
 ## 24.1 Quando usare un workflow (vs subagent vs skill)

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -9,6 +9,12 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 **Politica di retention**: ultimi 30 giorni. Le entry piu' vecchie sono cancellate (per evitare crescita illimitata del file). La storia completa resta comunque tracciabile via `git log README.md`.
 
+## 2026-07-06
+
+> Nessuna novita' significativa nelle ultime 24 ore.
+
+---
+
 ## 2026-07-05
 
 > Nessuna novita' significativa nelle ultime 24 ore.


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily` ([automation README](../tree/main/automations/daily-whats-new)).

## Novita' rilevate (24h)

- **CLI v2.1.202** (6 lug, 22:51 UTC): nuova setting "Dynamic workflow size" in `/config`, attributi OTel `workflow.run_id`/`workflow.name`, `/review <pr>` tornato single-pass veloce (usa `/code-review <level> <pr#>` per la review multi-agente), bundle di 15+ fix di affidabilita' (Ctrl+R history search, `/rename` sessioni background, Remote Control, resume con worktree multipli, voice dictation, installer download). Fonte: [GitHub Releases v2.1.202](https://github.com/anthropics/claude-code/releases/tag/v2.1.202).

Nessuna novita' rilevante da Anthropic blog o dai profili X monitorati nelle ultime 24 ore (nessun nuovo post di @bcherny, @_catwu, @noahzweben, @trq212, @claudeai, @ClaudeDevs, @alistaiir oltre quanto gia' archiviato).

## Note

- Nota: questa sessione ha sviluppato sul branch designato dall'ambiente (`claude/peaceful-volta-6b1wd9`) anziche' su un branch `whats-new/YYYY-MM-DD` dedicato, per rispettare il vincolo "non pushare su branch diversi da quello assegnato" della sessione corrente.

Verificare:
- [ ] Sezione 'What's new today' nel README aggiornata
- [ ] Sezione precedente archiviata in docs/whats-new-archive.md
- [ ] Callout aggiunti coerenti con i doc target
- [ ] Niente duplicati con ultime 7 entry archive

Auto-merge non attivo per default. Mergiare manualmente se OK.


---
_Generated by [Claude Code](https://claude.ai/code/session_015UFmvq9aB23aLEPsPCYZg4)_