### PR TITLE
What's new 2026-07-08

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-07-06)
+## What's new today (2026-07-08)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-> Nessuna novita' significativa nelle ultime 24 ore. Prossimo aggiornamento domani 07:00.
+- **CLI v2.1.204** (release, 8 lug): hotfix per gli eventi hook che non venivano trasmessi durante gli hook `SessionStart` nelle sessioni headless — evitava che i worker remoti fossero terminati come inattivi a meta' hook. Fonte: [GitHub Releases v2.1.204](https://github.com/anthropics/claude-code/releases/tag/v2.1.204). Vedi [docs/07-hooks.md](./docs/07-hooks.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **CLI v2.1.203** (release, 7 lug): batch di fix per le sessioni background — risolve lo stallo di 15-20s all'apertura su macOS, le sessioni bloccate per token daemon stale, il drop di `ANTHROPIC_BASE_URL`/`PATH`, i problemi di worktree isolation, e introduce un toggle VS Code per abilitare Remote Control su tutte le sessioni. Fonte: [GitHub Releases v2.1.203](https://github.com/anthropics/claude-code/releases/tag/v2.1.203). Vedi [docs/08-subagents.md](./docs/08-subagents.md), [docs/17-ide-surface.md](./docs/17-ide-surface.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **Claude Code e Cowork arrivano al governo** (annuncio, 7 lug): beta pubblica in Claude for Government Desktop, ambiente FedRAMP High — governance per dipartimento, limiti di spesa e audit log tamper-evident per il processo ATO. Fonte: [blog Anthropic](https://claude.com/blog/bringing-claude-code-and-claude-cowork-to-government). Vedi [docs/18-settings-auth.md](./docs/18-settings-auth.md).
+- **Claude Cowork su mobile e web** (annuncio, 7 lug): sessioni e file seguono l'utente su ogni device, lavoro in background senza device online, task pianificati, Chat e Cowork condividono un'unica home su web/desktop. Beta in rollout dal piano Max, limiti raddoppiati fino al 5 agosto. Fonte: [blog Anthropic](https://claude.com/blog/cowork-web-mobile) · [@claudeai](https://x.com/claudeai/status/2074525815820169320). Vedi [docs/17-ide-surface.md](./docs/17-ide-surface.md).
+- **Fable 5 esteso su tutti i piani paid fino al 12 luglio** (post X, 7 lug): l'accesso a Claude Fable 5 su tutti i piani a pagamento, in scadenza il 7 luglio, viene prorogato al 12 luglio — resta il tetto del 50% dell'utilizzo settimanale, oltre il quale si attinge ai crediti di utilizzo. Fonte: [@claudeai](https://x.com/claudeai/status/2074548242386178258). Vedi [docs/05-fast-mode-1m-context.md](./docs/05-fast-mode-1m-context.md).
 
 ---
 

--- a/docs/05-fast-mode-1m-context.md
+++ b/docs/05-fast-mode-1m-context.md
@@ -171,6 +171,8 @@ Opus 4.7 rimane disponibile via `/model claude-opus-4-7` o `/effort` manuale. Pe
 ### Annunciato
 v2.1.170 (9 giugno 2026). `claude-fable-5` e' il primo modello **Mythos-class** di Anthropic disponibile pubblicamente — prestazioni superiori a qualsiasi modello precedentemente rilasciato al pubblico, ottimizzato per reasoning profondo e lavoro agentico di lunga durata.
 
+> **2026-07-08 (auto-update)**: l'accesso a Fable 5 su tutti i piani paid, in scadenza il 7 luglio, viene prorogato al 12 luglio — resta il tetto del 50% dell'utilizzo settimanale. Fonte: [@claudeai](https://x.com/claudeai/status/2074548242386178258). Vedi anche README "What's new today" del giorno.
+
 ### Come si usa in Claude Code
 ```bash
 /model claude-fable-5

--- a/docs/07-hooks.md
+++ b/docs/07-hooks.md
@@ -17,6 +17,8 @@ Gli hook permettono di intercettare deterministicamente il lifecycle di Claude C
 
 > Fonte: [`/en/hooks`](https://code.claude.com/docs/en/hooks).
 
+> **2026-07-08 (auto-update)**: CLI v2.1.204 corregge un bug per cui gli eventi hook non venivano trasmessi durante `SessionStart` nelle sessioni headless, causando idle-reap dei worker remoti a meta' hook. Fonte: [GitHub Releases v2.1.204](https://github.com/anthropics/claude-code/releases/tag/v2.1.204). Vedi anche README "What's new today" del giorno.
+
 ---
 
 ## 7.1 Eventi supportati (28+)

--- a/docs/08-subagents.md
+++ b/docs/08-subagents.md
@@ -17,6 +17,8 @@ Subagent = AI assistant specializzato con context window proprio, system prompt 
 
 > "Each subagent runs in its own context window with a custom system prompt, specific tool access, and independent permissions." — [`/en/sub-agents`](https://code.claude.com/docs/en/sub-agents)
 
+> **2026-07-08 (auto-update)**: CLI v2.1.203 risolve un batch di bug sulle sessioni background — token daemon stale che le bloccava permanentemente (ora auto-recovery), `claude agents` che fermava silenziosamente subagent in corso, `PATH`/`ANTHROPIC_BASE_URL` stale ereditati dal daemon. Fonte: [GitHub Releases v2.1.203](https://github.com/anthropics/claude-code/releases/tag/v2.1.203). Vedi anche README "What's new today" del giorno.
+
 ---
 
 ## 8.1 Dove vivono

--- a/docs/17-ide-surface.md
+++ b/docs/17-ide-surface.md
@@ -178,6 +178,8 @@ claude --rc [name]                   # alias
 
 > Fonte: [`/en/remote-control`](https://code.claude.com/docs/en/remote-control).
 
+> **2026-07-08 (auto-update)**: CLI v2.1.203 aggiunge in VS Code un toggle Settings "Enable Remote Control for all sessions". Fonte: [GitHub Releases v2.1.203](https://github.com/anthropics/claude-code/releases/tag/v2.1.203). Vedi anche README "What's new today" del giorno.
+
 ---
 
 ## 17.7 Computer use {#computer-use}
@@ -220,6 +222,8 @@ Vedi [10 MCP § 10.8 Channels](./10-mcp.md#10.8-channels-research-preview).
 ---
 
 ## 17.10 Mobile (iOS app + Android via web)
+
+> **2026-07-08 (auto-update)**: Claude Cowork si espande a mobile e web (beta, dal piano Max): sessioni e file seguono l'utente su ogni device, lavoro in background senza device online, task pianificati; limiti raddoppiati fino al 5 agosto. Fonte: [blog Anthropic](https://claude.com/blog/cowork-web-mobile). Vedi anche README "What's new today" del giorno.
 
 - iOS app: download da App Store
 - Android: via mobile web (claude.ai/code)

--- a/docs/18-settings-auth.md
+++ b/docs/18-settings-auth.md
@@ -327,6 +327,8 @@ La scelta tra **subscription OAuth** (Claude Pro/Max/Team/Enterprise) e **API ke
 
 ## 18.6 Claude for Teams / Enterprise
 
+> **2026-07-08 (auto-update)**: Claude Code e Claude Cowork entrano in beta pubblica su Claude for Government Desktop, ambiente FedRAMP High — governance per dipartimento, spending limit e audit log tamper-evident per il processo ATO. Fonte: [blog Anthropic](https://claude.com/blog/bringing-claude-code-and-claude-cowork-to-government). Vedi anche README "What's new today" del giorno.
+
 | Feature | Teams | Enterprise |
 |---|---|---|
 | Self-service | ✓ | |

--- a/docs/19-changelog.md
+++ b/docs/19-changelog.md
@@ -534,8 +534,10 @@ Vedi anche [@bcherny](https://x.com/bcherny/status/2047375800945783056).
 | 2 lug 2026 | — | **Artifacts esteso a Pro e Max**: Artifacts in Claude Code (pagine web condivisibili da sessione) ora disponibili su Pro e Max — prima solo Team/Enterprise. [@ClaudeDevs](https://x.com/ClaudeDevs/status/2072770790114914317). |
 | 3 lug 2026 | **v2.1.200** | **Permission mode rinominato `manual`**: il mode `default` diventa `manual` in CLI, VS Code e JetBrains (comportamento invariato — solo reads auto). `AskUserQuestion` no auto-continue by default; opt-in via `/config`. Accessibilita': screen reader migliorato, nested tables come "Header: value". Fix: sessioni background interrotte da sleep/wake, subagent tagliati da rate limit, flicker tmux 3.4+. |
 | 3 lug 2026 | v2.1.201 | Fix: sessioni Sonnet 5 non usano piu' mid-conversation system role per harness reminders. |
+| 7 lug 2026 | **v2.1.203** | Batch di fix per sessioni background: stallo 15-20s in apertura su macOS (falsa detection low-memory, regressione 2.1.196), sessioni bloccate per token daemon stale (ora auto-recovery), `claude agents` che silenziosamente fermava subagent in corso, `PATH`/`ANTHROPIC_BASE_URL` stale ereditati dal daemon, worktree isolation e multi-repo workspace. Nuovo warning scadenza login prima che interrompa sessioni background. Badge grigio ⏸ in footer per permission mode `manual`. Binary size -7MB, startup memory -7MB. [VS Code] toggle Settings "Enable Remote Control for all sessions". |
+| 8 lug 2026 | v2.1.204 | Fix: eventi hook non trasmessi durante hook `SessionStart` in sessioni headless — causava idle-reap dei worker remoti a meta' hook. |
 
-<sub>Aggiornato 2026-07-04 via daily what's new. Fonte: [GitHub Releases v2.1.200](https://github.com/anthropics/claude-code/releases/tag/v2.1.200).</sub>
+<sub>Aggiornato 2026-07-08 via daily what's new. Fonte: [GitHub Releases v2.1.203](https://github.com/anthropics/claude-code/releases/tag/v2.1.203), [v2.1.204](https://github.com/anthropics/claude-code/releases/tag/v2.1.204).</sub>
 
 ---
 

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -9,6 +9,12 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 **Politica di retention**: ultimi 30 giorni. Le entry piu' vecchie sono cancellate (per evitare crescita illimitata del file). La storia completa resta comunque tracciabile via `git log README.md`.
 
+## 2026-07-06
+
+> Nessuna novita' significativa nelle ultime 24 ore.
+
+---
+
 ## 2026-07-05
 
 > Nessuna novita' significativa nelle ultime 24 ore.
@@ -191,20 +197,6 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 ---
 
 ## 2026-06-07
-
-> Nessuna novita' significativa nelle ultime 24 ore.
-
----
-
-## 2026-06-06
-
-- **`fallbackModel` setting** (v2.1.166, 6 giu): il campo `fallbackModel` in `settings.json` configura fino a 3 modelli di fallback provati in sequenza quando il primario e' sovraccarico o non disponibile; `--fallback-model` funziona ora anche nelle sessioni interattive (in precedenza solo in modalita' `-p`). Fonte: [GitHub Releases v2.1.166](https://github.com/anthropics/claude-code/releases/tag/v2.1.166). Doc: [docs/18-settings-auth.md](./docs/18-settings-auth.md), [docs/19-changelog.md](./docs/19-changelog.md).
-- **Thinking Token Control** (v2.1.166, 6 giu): `MAX_THINKING_TOKENS=0`, `--thinking disabled` e il toggle per-modello disattivano il thinking su modelli che lo abilitano di default via Claude API — per output piu' rapidi o deterministici nei workflow API. Fonte: [GitHub Releases v2.1.166](https://github.com/anthropics/claude-code/releases/tag/v2.1.166). Doc: [docs/05-fast-mode-1m-context.md](./docs/05-fast-mode-1m-context.md), [docs/18-settings-auth.md](./docs/18-settings-auth.md).
-- **Cross-session messaging hardening** (v2.1.166, 6 giu): i messaggi inoltrati via `SendMessage` da altre sessioni Claude non portano piu' l'autorita' dell'utente; i ricevitori rifiutano le richieste di permesso inoltrate e auto mode le blocca — rafforza la sicurezza nei workflow multi-agente con `SendMessage`. Fonte: [GitHub Releases v2.1.166](https://github.com/anthropics/claude-code/releases/tag/v2.1.166). Doc: [docs/08-subagents.md](./docs/08-subagents.md).
-
----
-
-## 2026-06-05
 
 > Nessuna novita' significativa nelle ultime 24 ore.
 


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h (2026-07-07 07:00 → 2026-07-08 07:00 Europe/Rome).

Generato dalla routine `whats-new-daily`.

## Voci TLDR (5)
- **CLI v2.1.204** (release, 8 lug) — fix hook events non trasmessi durante `SessionStart` in sessioni headless.
- **CLI v2.1.203** (release, 7 lug) — batch di fix sessioni background, worktree, Remote Control (VS Code toggle).
- **Claude Code e Cowork per il governo** (annuncio, 7 lug) — beta pubblica FedRAMP High.
- **Claude Cowork su mobile e web** (annuncio, 7 lug) — beta piano Max, limiti raddoppiati fino al 5 agosto.
- **Fable 5 esteso su tutti i piani paid fino al 12 luglio** (post X, 7 lug).

## File modificati
- `README.md` — sezione "What's new today" sostituita (2026-07-06 → 2026-07-08)
- `docs/whats-new-archive.md` — archiviata la sezione 2026-07-06, retention 30 giorni applicata
- `docs/19-changelog.md` — aggiunte righe v2.1.203 / v2.1.204 alla tabella versione per versione
- `docs/07-hooks.md`, `docs/08-subagents.md`, `docs/17-ide-surface.md` (x2), `docs/18-settings-auth.md`, `docs/05-fast-mode-1m-context.md` — callout auto-update

## Verificare
- [ ] Sezione 'What's new today' nel README aggiornata
- [ ] Sezione precedente archiviata in docs/whats-new-archive.md
- [ ] Callout aggiunti coerenti con i doc target
- [ ] Niente duplicati con ultime 7 entry archive

## Nota
Il run precedente (2026-07-07) risulta assente sia in README che in archive — probabile skip della routine quel giorno. Questo run copre solo le ultime 24h (07-07 07:00 → 08-08 07:00 CEST) come da istruzioni; non ho colmato retroattivamente il buco del 07-07 (inclusa la release v2.1.202 del 6 luglio) per restare nello scope del giorno.

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Ztac14DQsfsU5RZyDdr8K)_