### PR TITLE
What's new 2026-07-09

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-07-08)
+## What's new today (2026-07-09)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-- **Dynamic workflow size** in `/config` (v2.1.202, 6 lug): linea guida small/medium/large su quanti agent Claude tende a usare quando scrive un [dynamic workflow](./docs/24-workflows.md) — indicativa, non un tetto imposto dal runtime. Stessa release: attributi OpenTelemetry `workflow.run_id`/`workflow.name` per ricostruire l'attivita' di un run, e `/review <PR>` torna a single-pass veloce (multi-agent resta su `/code-review <level> <PR#>`). Fonte: [GitHub Releases v2.1.202](https://github.com/anthropics/claude-code/releases/tag/v2.1.202). Doc: [docs/24-workflows.md](./docs/24-workflows.md), [docs/03-slash-commands.md](./docs/03-slash-commands.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **v2.1.205** (8 lug): auto mode blocca ora la manomissione dei file di transcript di sessione; `/doctor` diventa un checkup completo del setup con diagnosi e fix automatici, `/checkup` ne e' il nuovo alias. Fix rilevanti: messaggi persi al limite `--max-turns`, stato "needs input"/"working" instabile per gli agent in background, cancellazione file fuori worktree su Windows (junction NTFS), crash su file watcher e directory rimosse, `claude mcp add-from-claude-desktop` bloccato con nomi server non supportati. Download auto-update ora in streaming su disco (picco memoria -400MB). Fonte: [GitHub Releases v2.1.205](https://github.com/anthropics/claude-code/releases/tag/v2.1.205). Doc: [docs/04-modalita-permessi.md](./docs/04-modalita-permessi.md), [docs/03-slash-commands.md](./docs/03-slash-commands.md), [docs/08-subagents.md](./docs/08-subagents.md), [docs/19-changelog.md](./docs/19-changelog.md).
 
 ---
 

--- a/docs/03-slash-commands.md
+++ b/docs/03-slash-commands.md
@@ -112,6 +112,8 @@ Riferimento completo dei comandi `/` built-in e bundled skills al v2.1.183. Type
 <sub>Aggiornato 2026-06-19 via daily what's new. Fonte: [GitHub Releases v2.1.183](https://github.com/anthropics/claude-code/releases/tag/v2.1.183) · [@ClaudeDevs](https://x.com/ClaudeDevs/status/2067391951725629941).</sub>
 <sub>Aggiornato 2026-07-08 via daily what's new. Fonte: [GitHub Releases v2.1.202](https://github.com/anthropics/claude-code/releases/tag/v2.1.202).</sub>
 
+> **2026-07-09 (auto-update)**: v2.1.205 trasforma `/doctor` in un checkup completo del setup, con diagnosi e fix automatico; `/checkup` e' il nuovo alias. Fonte: [GitHub Releases v2.1.205](https://github.com/anthropics/claude-code/releases/tag/v2.1.205). Vedi anche README "What's new today" del giorno.
+
 ---
 
 ## 3.2 Comandi rimossi / migrati

--- a/docs/04-modalita-permessi.md
+++ b/docs/04-modalita-permessi.md
@@ -91,6 +91,8 @@ Da agosto 2025: Opus 4.x per plan + Sonnet per execution. [@_catwu](https://x.co
 
 Lanciato w13 (24 mar 2026). Alternativa piu' sicura a `--dangerously-skip-permissions`: un classifier separato decide cosa Claude puo' fare senza chiedere.
 
+> **2026-07-09 (auto-update)**: v2.1.205 aggiunge una regola auto mode che blocca la manomissione dei file di transcript di sessione, e un prompt di conferma prima di eseguire `rm -rf` su variabili non risolte. Fonte: [GitHub Releases v2.1.205](https://github.com/anthropics/claude-code/releases/tag/v2.1.205). Vedi anche README "What's new today" del giorno.
+
 ### Caratteristiche
 - Classifier model review actions (separato dal main model)
 - Boundaries dichiarate in conversation rispettate (ma non rules permanenti)

--- a/docs/08-subagents.md
+++ b/docs/08-subagents.md
@@ -111,6 +111,8 @@ claude agents                  # Agent View (lista + stato sessioni)
 
 <sub>Aggiornato 2026-06-11 via daily what's new. Fonte: [GitHub Releases v2.1.172](https://github.com/anthropics/claude-code/releases/tag/v2.1.172).</sub>
 
+> **2026-07-09 (auto-update)**: v2.1.205 fa linkare in `claude agents` la PR quando una sessione la edita/mergia/commenta/pusha; righe con stato colorato e headline generata dal classifier. Fix: stato "needs input"/"working" che sfarfallava per gli agent in background dopo un resume, e sessioni mostrate come "failed"/"completed" dopo un `SendMessage` di ripresa. Fonte: [GitHub Releases v2.1.205](https://github.com/anthropics/claude-code/releases/tag/v2.1.205). Vedi anche README "What's new today" del giorno.
+
 ### Dal main agent
 Claude usa il tool **Agent** specificando `subagent_type`:
 ```json

--- a/docs/19-changelog.md
+++ b/docs/19-changelog.md
@@ -3,7 +3,7 @@
 > 📍 [README](../README.md) → [Riferimenti](../README.md#riferimenti) → **19 Changelog**
 > 📚 Riferimento · 🟢 Beginner-friendly
 
-Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (8 luglio 2026, v2.1.204). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
+Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (8 luglio 2026, v2.1.205). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
 
 ## Cosa e' concettualmente
 
@@ -537,8 +537,9 @@ Vedi anche [@bcherny](https://x.com/bcherny/status/2047375800945783056).
 | 6 lug 2026 | **v2.1.202** | **Dynamic workflow size** in `/config`: linea guida small/medium/large su quanti agent Claude tende a usare in un [dynamic workflow](./24-workflows.md) (indicativa, non un tetto). Attributi OpenTelemetry `workflow.run_id`/`workflow.name` sugli agent spawnati da workflow. `/review <PR>` torna a single-pass veloce (multi-agent resta su `/code-review <level> <PR#>`). Fix: crash ricerca history Ctrl+R, `/rename` su sessioni background revertito al restart job, handshake mTLS durante rotazione certificati, comandi da Remote Control falliti in sessioni interattive, allegati Remote Control senza caption scartati silenziosamente, skill ricaricate che duplicavano le istruzioni nel context. |
 | 7 lug 2026 | v2.1.203 | Warning di scadenza login prima che interrompa le sessioni background. Badge grigio ⏠ in footer per il permission mode manual. Working directory di sessione esposte a MCP `roots/list` con change notification. Fix: falso rilevamento low-memory su macOS (regressione v2.1.196), sessioni background bloccate in modo permanente, PATH stale su Windows per background agent, worktree annidati, auto-upgrade daemon che uccideva sessioni. |
 | 8 lug 2026 | v2.1.204 | Fix: eventi hook non streammati durante `SessionStart` in sessioni headless, poteva causare idle-reap dei remote worker a meta' hook. |
+| 8 lug 2026 | **v2.1.205** | **Auto mode**: nuova regola blocca la manomissione dei file di transcript di sessione; prompt di conferma prima di eseguire `rm -rf` su variabili non risolte. **`/doctor`** diventa un checkup completo del setup (diagnosi + fix automatico); **`/checkup`** e' il nuovo alias. **Agent view**: sessioni che editano/mergiano/commentano/pushano su una PR esistente ora linkano la PR in `claude agents`; righe con stato colorato e headline generata dal classifier. Fix: messaggi persi al limite `--max-turns`, stato "needs input"/"working" instabile per agent in background dopo resume, cancellazione file fuori worktree su Windows (junction/symlink NTFS), `claude mcp add-from-claude-desktop` bloccato con nomi server non supportati, crash plugin LSP che impediva ad altri server validi di gestire la stessa estensione, crash Windows su directory di lancio rimossa/lockata/smontata, crash file watcher durante scan directory. Download auto-update ora in streaming su disco (picco memoria -400MB). |
 
-<sub>Aggiornato 2026-07-08 via daily what's new. Fonte: [GitHub Releases v2.1.202](https://github.com/anthropics/claude-code/releases/tag/v2.1.202) · [v2.1.203](https://github.com/anthropics/claude-code/releases/tag/v2.1.203) · [v2.1.204](https://github.com/anthropics/claude-code/releases/tag/v2.1.204).</sub>
+<sub>Aggiornato 2026-07-09 via daily what's new. Fonte: [GitHub Releases v2.1.202](https://github.com/anthropics/claude-code/releases/tag/v2.1.202) · [v2.1.203](https://github.com/anthropics/claude-code/releases/tag/v2.1.203) · [v2.1.204](https://github.com/anthropics/claude-code/releases/tag/v2.1.204) · [v2.1.205](https://github.com/anthropics/claude-code/releases/tag/v2.1.205).</sub>
 
 ---
 

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -9,6 +9,12 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 **Politica di retention**: ultimi 30 giorni. Le entry piu' vecchie sono cancellate (per evitare crescita illimitata del file). La storia completa resta comunque tracciabile via `git log README.md`.
 
+## 2026-07-08
+
+- **Dynamic workflow size** in `/config` (v2.1.202, 6 lug): linea guida small/medium/large su quanti agent Claude tende a usare quando scrive un [dynamic workflow](./24-workflows.md) — indicativa, non un tetto imposto dal runtime. Stessa release: attributi OpenTelemetry `workflow.run_id`/`workflow.name` per ricostruire l'attivita' di un run, e `/review <PR>` torna a single-pass veloce (multi-agent resta su `/code-review <level> <PR#>`). Fonte: [GitHub Releases v2.1.202](https://github.com/anthropics/claude-code/releases/tag/v2.1.202). Doc: [24-workflows.md](./24-workflows.md), [03-slash-commands.md](./03-slash-commands.md), [19-changelog.md](./19-changelog.md).
+
+---
+
 ## 2026-07-06
 
 > Nessuna novita' significativa nelle ultime 24 ore.
@@ -191,12 +197,6 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 ---
 
 ## 2026-06-08
-
-> Nessuna novita' significativa nelle ultime 24 ore.
-
----
-
-## 2026-06-07
 
 > Nessuna novita' significativa nelle ultime 24 ore.
 


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily` ([automation README](../tree/main/automations/daily-whats-new)).

## Novita' rilevata

- **v2.1.205** (GitHub Releases, 8 lug 21:22 UTC): auto mode blocca la manomissione dei file di transcript di sessione e chiede conferma prima di `rm -rf` su variabili non risolte; `/doctor` diventa un checkup completo del setup, `/checkup` e' il nuovo alias; agent view linka la PR per sessioni che editano/mergiano/pushano; fix per stato instabile "needs input"/"working" negli agent in background, cancellazione file fuori worktree su Windows, crash plugin LSP, crash file watcher, e altri bugfix minori.
- Nessuna novita' aggiuntiva rilevata da changelog ufficiale, Anthropic news/blog o account X del team Claude Code nelle ultime 24 ore (WebFetch su x.com ha restituito 402/403 come da fallback previsto; verificato via WebSearch).

## Verificare

- [x] Sezione 'What's new today' nel README aggiornata
- [x] Sezione precedente (2026-07-08) archiviata in docs/whats-new-archive.md
- [x] Callout aggiunti coerenti con i doc target (docs/04, docs/03, docs/08, docs/19)
- [x] Niente duplicati con ultime 7 entry archive

Nota: la PR del giorno precedente (2026-07-08) risultava gia' mergiata in `main` — questo branch e' stato ripartito dall'ultimo main prima di applicare le nuove modifiche, come da procedura.

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6W4GZYCGve2XqbNCnCbDE)_