### PR TITLE
What's new 2026-07-11

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-07-08)
+## What's new today (2026-07-11)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-- **Dynamic workflow size** in `/config` (v2.1.202, 6 lug): linea guida small/medium/large su quanti agent Claude tende a usare quando scrive un [dynamic workflow](./docs/24-workflows.md) — indicativa, non un tetto imposto dal runtime. Stessa release: attributi OpenTelemetry `workflow.run_id`/`workflow.name` per ricostruire l'attivita' di un run, e `/review <PR>` torna a single-pass veloce (multi-agent resta su `/code-review <level> <PR#>`). Fonte: [GitHub Releases v2.1.202](https://github.com/anthropics/claude-code/releases/tag/v2.1.202). Doc: [docs/24-workflows.md](./docs/24-workflows.md), [docs/03-slash-commands.md](./docs/03-slash-commands.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **CLI v2.1.207** (11 lug): auto mode diventa disponibile senza opt-in `CLAUDE_CODE_ENABLE_AUTO_MODE` su Bedrock, Vertex AI e Foundry. Bedrock, Vertex e Claude Platform su AWS passano a **Opus 4.8** come modello default. Fix: freeze del terminale su output molto lunghi, dialog di sicurezza bypassato su remote managed settings, auto-updater che sovrascriveva launcher custom. Fonte: [GitHub Releases v2.1.207](https://github.com/anthropics/claude-code/releases/tag/v2.1.207). Vedi [docs/04 § 4.3 Auto mode](./docs/04-modalita-permessi.md), [docs/18 § 18.5 Authentication](./docs/18-settings-auth.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **CLI v2.1.206** (10 lug): `/cd` suggerisce ora i path delle directory come `/add-dir`; `/commit-push-pr` auto-allowa il `git push` verso il remote di push configurato; `/login` supporta gli endpoint gateway pubblici gestiti da Anthropic. Fonte: [GitHub Releases v2.1.206](https://github.com/anthropics/claude-code/releases/tag/v2.1.206). Vedi [docs/03-slash-commands.md](./docs/03-slash-commands.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **CLI v2.1.205** (8 lug): nuova auto mode rule blocca il tampering dei file di transcript della sessione; fix `--json-schema` che produceva output non strutturato con schema non validi, rimozione worktree su Windows che cancellava file fuori dalla worktree. Fonte: [GitHub Releases v2.1.205](https://github.com/anthropics/claude-code/releases/tag/v2.1.205). Vedi [docs/04-modalita-permessi.md](./docs/04-modalita-permessi.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **Automated security reviews** (annuncio blog, 7 lug): revisioni di sicurezza automatiche sulle PR tramite il comando `/security-review` e una nuova integrazione GitHub Actions ufficiale — Claude identifica i problemi di sicurezza e puo' anche risolverli. Fonte: [Anthropic blog](https://www.anthropic.com/news/automate-security-reviews-with-claude-code). Vedi [docs/03-slash-commands.md](./docs/03-slash-commands.md).
 
 ---
 

--- a/docs/03-slash-commands.md
+++ b/docs/03-slash-commands.md
@@ -15,6 +15,8 @@ Riferimento completo dei comandi `/` built-in e bundled skills al v2.1.183. Type
 
 **Per il deep-dive**: [09 — Skills](./09-skills.md) per come scrivere i tuoi.
 
+> **2026-07-11 (auto-update)**: da v2.1.206 `/cd` suggerisce i path delle directory come `/add-dir`, `/commit-push-pr` auto-allowa il `git push` verso il remote di push configurato e `/login` supporta gli endpoint gateway pubblici Anthropic. `/security-review` guadagna un'integrazione GitHub Actions ufficiale per revisioni di sicurezza automatiche sulle PR. Fonte: [GitHub Releases v2.1.206](https://github.com/anthropics/claude-code/releases/tag/v2.1.206) · [Anthropic blog](https://www.anthropic.com/news/automate-security-reviews-with-claude-code). Vedi anche README "What's new today" del giorno.
+
 ---
 
 ## 3.1 Tabella completa

--- a/docs/04-modalita-permessi.md
+++ b/docs/04-modalita-permessi.md
@@ -91,6 +91,8 @@ Da agosto 2025: Opus 4.x per plan + Sonnet per execution. [@_catwu](https://x.co
 
 Lanciato w13 (24 mar 2026). Alternativa piu' sicura a `--dangerously-skip-permissions`: un classifier separato decide cosa Claude puo' fare senza chiedere.
 
+> **2026-07-11 (auto-update)**: da v2.1.207 auto mode e' disponibile su Bedrock, Vertex AI e Foundry **senza** l'opt-in `CLAUDE_CODE_ENABLE_AUTO_MODE` (disattivabile via `disableAutoMode`); da v2.1.205 una nuova rule blocca il tampering dei file di transcript della sessione. Fonte: [GitHub Releases v2.1.207](https://github.com/anthropics/claude-code/releases/tag/v2.1.207) · [v2.1.205](https://github.com/anthropics/claude-code/releases/tag/v2.1.205). Vedi anche README "What's new today" del giorno.
+
 ### Caratteristiche
 - Classifier model review actions (separato dal main model)
 - Boundaries dichiarate in conversation rispettate (ma non rules permanenti)

--- a/docs/18-settings-auth.md
+++ b/docs/18-settings-auth.md
@@ -260,6 +260,8 @@ Da v2.1.111: read-only bash glob + `cd <project-dir> &&` no prompt.
 
 ## 18.5 Authentication
 
+> **2026-07-11 (auto-update)**: da v2.1.207 Bedrock, Vertex AI e Claude Platform su AWS passano a **Opus 4.8** come modello default (prima Opus 4.7). Fonte: [GitHub Releases v2.1.207](https://github.com/anthropics/claude-code/releases/tag/v2.1.207). Vedi anche README "What's new today" del giorno.
+
 ### Storage
 - macOS: Keychain (encrypted)
 - Linux/Windows: `~/.claude/.credentials.json` (mode 0600 / user profile ACLs)

--- a/docs/19-changelog.md
+++ b/docs/19-changelog.md
@@ -3,7 +3,7 @@
 > 📍 [README](../README.md) → [Riferimenti](../README.md#riferimenti) → **19 Changelog**
 > 📚 Riferimento · 🟢 Beginner-friendly
 
-Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (8 luglio 2026, v2.1.204). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
+Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (11 luglio 2026, v2.1.207). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
 
 ## Cosa e' concettualmente
 
@@ -537,8 +537,11 @@ Vedi anche [@bcherny](https://x.com/bcherny/status/2047375800945783056).
 | 6 lug 2026 | **v2.1.202** | **Dynamic workflow size** in `/config`: linea guida small/medium/large su quanti agent Claude tende a usare in un [dynamic workflow](./24-workflows.md) (indicativa, non un tetto). Attributi OpenTelemetry `workflow.run_id`/`workflow.name` sugli agent spawnati da workflow. `/review <PR>` torna a single-pass veloce (multi-agent resta su `/code-review <level> <PR#>`). Fix: crash ricerca history Ctrl+R, `/rename` su sessioni background revertito al restart job, handshake mTLS durante rotazione certificati, comandi da Remote Control falliti in sessioni interattive, allegati Remote Control senza caption scartati silenziosamente, skill ricaricate che duplicavano le istruzioni nel context. |
 | 7 lug 2026 | v2.1.203 | Warning di scadenza login prima che interrompa le sessioni background. Badge grigio ⏠ in footer per il permission mode manual. Working directory di sessione esposte a MCP `roots/list` con change notification. Fix: falso rilevamento low-memory su macOS (regressione v2.1.196), sessioni background bloccate in modo permanente, PATH stale su Windows per background agent, worktree annidati, auto-upgrade daemon che uccideva sessioni. |
 | 8 lug 2026 | v2.1.204 | Fix: eventi hook non streammati durante `SessionStart` in sessioni headless, poteva causare idle-reap dei remote worker a meta' hook. |
+| 8 lug 2026 | v2.1.205 | Nuova auto mode rule blocca il tampering dei file di transcript della sessione. Fix: `--json-schema` produceva silenziosamente output non strutturato con schema non validi, messaggi inviati durante il turno persi al limite `--max-turns`, rimozione worktree su Windows che cancellava file fuori dalla worktree (NTFS junction), background agent bloccati in stato ambiguo in lista, `claude attach` in errore su agent a meta' upgrade. |
+| 10 lug 2026 | **v2.1.206** | **`/cd`** suggerisce ora i path delle directory come `/add-dir`. **`/doctor`** propone il trimming dei `CLAUDE.md` committati troppo grandi. **`/commit-push-pr`** auto-allowa il `git push` verso il remote di push configurato (non solo `origin`). Gateway: `/login` supporta gli endpoint gateway pubblici gestiti da Anthropic. `EnterWorktree` chiede conferma prima di entrare in worktree fuori da `.claude/worktrees/`. Background agent si aggiornano in automatico dopo un update di Claude Code. |
+| 11 lug 2026 | **v2.1.207** | **Auto mode** disponibile senza opt-in `CLAUDE_CODE_ENABLE_AUTO_MODE` su Bedrock, Vertex AI e Foundry (disattivabile via `disableAutoMode`). Bedrock, Vertex e Claude Platform su AWS passano a **Opus 4.8** come modello default. Fix: freeze del terminale su liste/tabelle/code block molto lunghi, remote managed settings registrate come consentite senza mostrare il dialog di sicurezza, auto-updater che sovrascriveva i launcher custom in `~/.local/bin/claude` (ora `/doctor` segnala il launcher gestito esternamente), falsi warning di prompt-injection su aggiornamenti di sistema benigni. |
 
-<sub>Aggiornato 2026-07-08 via daily what's new. Fonte: [GitHub Releases v2.1.202](https://github.com/anthropics/claude-code/releases/tag/v2.1.202) · [v2.1.203](https://github.com/anthropics/claude-code/releases/tag/v2.1.203) · [v2.1.204](https://github.com/anthropics/claude-code/releases/tag/v2.1.204).</sub>
+<sub>Aggiornato 2026-07-11 via daily what's new. Fonte: [GitHub Releases v2.1.205](https://github.com/anthropics/claude-code/releases/tag/v2.1.205) · [v2.1.206](https://github.com/anthropics/claude-code/releases/tag/v2.1.206) · [v2.1.207](https://github.com/anthropics/claude-code/releases/tag/v2.1.207).</sub>
 
 ---
 

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -9,6 +9,12 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 **Politica di retention**: ultimi 30 giorni. Le entry piu' vecchie sono cancellate (per evitare crescita illimitata del file). La storia completa resta comunque tracciabile via `git log README.md`.
 
+## 2026-07-08
+
+- **Dynamic workflow size** in `/config` (v2.1.202, 6 lug): linea guida small/medium/large su quanti agent Claude tende a usare quando scrive un [dynamic workflow](./24-workflows.md) — indicativa, non un tetto imposto dal runtime. Stessa release: attributi OpenTelemetry `workflow.run_id`/`workflow.name` per ricostruire l'attivita' di un run, e `/review <PR>` torna a single-pass veloce (multi-agent resta su `/code-review <level> <PR#>`). Fonte: [GitHub Releases v2.1.202](https://github.com/anthropics/claude-code/releases/tag/v2.1.202). Doc: [docs/24-workflows.md](./24-workflows.md), [docs/03-slash-commands.md](./03-slash-commands.md), [docs/19-changelog.md](./19-changelog.md).
+
+---
+
 ## 2026-07-06
 
 > Nessuna novita' significativa nelle ultime 24 ore.
@@ -191,12 +197,6 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 ---
 
 ## 2026-06-08
-
-> Nessuna novita' significativa nelle ultime 24 ore.
-
----
-
-## 2026-06-07
 
 > Nessuna novita' significativa nelle ultime 24 ore.
 


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily` ([automation README](../tree/main/automations/daily-whats-new)).

## Contenuto

- **CLI v2.1.207** (11 lug): auto mode GA su Bedrock/Vertex/Foundry senza opt-in, Opus 4.8 default su Bedrock/Vertex/AWS, vari fix (terminal freeze, consent dialog, auto-updater launcher).
- **CLI v2.1.206** (10 lug): `/cd` con path suggestions, `/commit-push-pr` auto-allow push, `/login` gateway pubblico.
- **CLI v2.1.205** (8 lug): auto mode rule anti-tampering transcript, fix `--json-schema` e worktree removal Windows.
- **Automated security reviews** (annuncio blog, 7 lug): `/security-review` + integrazione GitHub Actions ufficiale.

Nota: la finestra di ricerca stretta alle "ultime 24h" avrebbe coperto solo v2.1.207; dato che l'ultima run della routine risale al 2026-07-08, ho incluso anche v2.1.205/206 e l'annuncio del 7 lug per non lasciare gap nel changelog (nessuno di questi era gia' presente in archive/changelog).

## Verificare

- [ ] Sezione 'What's new today' nel README aggiornata
- [ ] Sezione precedente (2026-07-08) archiviata in docs/whats-new-archive.md
- [ ] Callout aggiunti coerenti nei doc target (docs/04, docs/18, docs/03)
- [ ] Niente duplicati con ultime 7 entry archive
- [ ] Tabella versioni in docs/19-changelog.md aggiornata (v2.1.205-207)

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtPBaeDCjuaq6tEk3W72hB)_