### PR TITLE
What's new 2026-07-12

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-07-08)
+## What's new today (2026-07-12)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-- **Dynamic workflow size** in `/config` (v2.1.202, 6 lug): linea guida small/medium/large su quanti agent Claude tende a usare quando scrive un [dynamic workflow](./docs/24-workflows.md) — indicativa, non un tetto imposto dal runtime. Stessa release: attributi OpenTelemetry `workflow.run_id`/`workflow.name` per ricostruire l'attivita' di un run, e `/review <PR>` torna a single-pass veloce (multi-agent resta su `/code-review <level> <PR#>`). Fonte: [GitHub Releases v2.1.202](https://github.com/anthropics/claude-code/releases/tag/v2.1.202). Doc: [docs/24-workflows.md](./docs/24-workflows.md), [docs/03-slash-commands.md](./docs/03-slash-commands.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **CLI v2.1.207** (11 lug): auto mode su Bedrock, Vertex AI e Foundry non richiede piu' l'opt-in `CLAUDE_CODE_ENABLE_AUTO_MODE=1` (disabilitabile via `disableAutoMode`); Bedrock/Vertex/Claude Platform su AWS passano a Opus 4.8 come modello default. Fix: freeze terminale su liste/tabelle molto lunghe in streaming, falsi warning prompt-injection, auto-updater che sovrascriveva launcher custom. Fonte: [GitHub Releases v2.1.207](https://github.com/anthropics/claude-code/releases/tag/v2.1.207). Vedi [docs/04-modalita-permessi.md § Auto mode](./docs/04-modalita-permessi.md) e [docs/19-changelog.md](./docs/19-changelog.md).
+- **`/doctor` diventa `/checkup`** (v2.1.206, 10 lug): checkup completo che diagnostica e puo' correggere in autonomia — skill/MCP/plugin inutilizzati, dedup `CLAUDE.md` locale vs versionato, hook lenti; chiede conferma prima di modificare qualsiasi cosa. Fonte: [@bcherny](https://x.com/bcherny/status/2074997570317779038) · [GitHub Releases v2.1.206](https://github.com/anthropics/claude-code/releases/tag/v2.1.206). Vedi [docs/03-slash-commands.md § 3.1](./docs/03-slash-commands.md), [docs/19-changelog.md](./docs/19-changelog.md).
 
 ---
 

--- a/docs/03-slash-commands.md
+++ b/docs/03-slash-commands.md
@@ -17,6 +17,8 @@ Riferimento completo dei comandi `/` built-in e bundled skills al v2.1.183. Type
 
 ---
 
+> **2026-07-12 (auto-update)**: da v2.1.206 `/doctor` diventa un checkup completo che diagnostica e puo' correggere i problemi (alias `/checkup`) — skill/MCP/plugin inutilizzati, dedup `CLAUDE.md`, hook lenti. Fonte: [@bcherny](https://x.com/bcherny/status/2074997570317779038) · [GitHub Releases v2.1.206](https://github.com/anthropics/claude-code/releases/tag/v2.1.206). Vedi anche README "What's new today" del giorno.
+
 ## 3.1 Tabella completa
 
 | Comando | Tipo | Funzione |

--- a/docs/04-modalita-permessi.md
+++ b/docs/04-modalita-permessi.md
@@ -138,6 +138,8 @@ Prima di questa release, auto mode richiedeva il provider diretto Anthropic (cla
 
 <sub>Aggiornato 2026-05-31 via daily what's new. Fonte: [GitHub Releases v2.1.158](https://github.com/anthropics/claude-code/releases/tag/v2.1.158).</sub>
 
+> **2026-07-12 (auto-update)**: da v2.1.207 auto mode su Bedrock, Vertex AI e Foundry non richiede piu' l'opt-in `CLAUDE_CODE_ENABLE_AUTO_MODE=1` (disabilitabile con `disableAutoMode` nei settings). Fonte: [GitHub Releases v2.1.207](https://github.com/anthropics/claude-code/releases/tag/v2.1.207). Vedi anche README "What's new today" del giorno.
+
 ### Hard deny rules (v2.1.134–136, Week 19)
 
 `settings.autoMode.hard_deny` definisce una lista di azioni bloccate incondizionatamente in auto mode, indipendentemente da eventuali eccezioni "allow" configurate. A differenza di `soft_deny`, le hard deny non possono essere sovrascritte da allow rules.

--- a/docs/19-changelog.md
+++ b/docs/19-changelog.md
@@ -3,7 +3,7 @@
 > 📍 [README](../README.md) → [Riferimenti](../README.md#riferimenti) → **19 Changelog**
 > 📚 Riferimento · 🟢 Beginner-friendly
 
-Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (8 luglio 2026, v2.1.204). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
+Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (11 luglio 2026, v2.1.207). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
 
 ## Cosa e' concettualmente
 
@@ -537,8 +537,11 @@ Vedi anche [@bcherny](https://x.com/bcherny/status/2047375800945783056).
 | 6 lug 2026 | **v2.1.202** | **Dynamic workflow size** in `/config`: linea guida small/medium/large su quanti agent Claude tende a usare in un [dynamic workflow](./24-workflows.md) (indicativa, non un tetto). Attributi OpenTelemetry `workflow.run_id`/`workflow.name` sugli agent spawnati da workflow. `/review <PR>` torna a single-pass veloce (multi-agent resta su `/code-review <level> <PR#>`). Fix: crash ricerca history Ctrl+R, `/rename` su sessioni background revertito al restart job, handshake mTLS durante rotazione certificati, comandi da Remote Control falliti in sessioni interattive, allegati Remote Control senza caption scartati silenziosamente, skill ricaricate che duplicavano le istruzioni nel context. |
 | 7 lug 2026 | v2.1.203 | Warning di scadenza login prima che interrompa le sessioni background. Badge grigio ⏠ in footer per il permission mode manual. Working directory di sessione esposte a MCP `roots/list` con change notification. Fix: falso rilevamento low-memory su macOS (regressione v2.1.196), sessioni background bloccate in modo permanente, PATH stale su Windows per background agent, worktree annidati, auto-upgrade daemon che uccideva sessioni. |
 | 8 lug 2026 | v2.1.204 | Fix: eventi hook non streammati durante `SessionStart` in sessioni headless, poteva causare idle-reap dei remote worker a meta' hook. |
+| 8 lug 2026 | **v2.1.205** | Auto mode rule blocca il tampering dei file di transcript di sessione e chiede conferma prima di un `rm -rf` su variabili non risolte. Auto-update ora scrive su disco in streaming invece di bufferizzare (-400 MB memoria). Fix: `--json-schema` produceva output non strutturato senza errore su schema invalidi; rimozione worktree su Windows cancellava file fuori dal worktree; sessioni background mostravano stato errato dopo resume; MCP init di un server bloccava l'inizializzazione di altri server validi. |
+| 10 lug 2026 | **v2.1.206** | **`/doctor`** diventa un checkup completo che diagnostica e puo' correggere i problemi trovati (alias **`/checkup`**). Suggerimenti path per `/cd`. `/commit-push-pr` auto-approva il push verso il remote configurato. Fix: errori di login scaduto con messaggi fuorvianti; MCP server che ignoravano `request_timeout_ms` per-server; server MCP OAuth che richiedevano ri-autenticazione manuale. Migliorata l'accuratezza del picker `/model` e la qualita' dei finding di `/code-review` su Opus 4.8. |
+| 11 lug 2026 | **v2.1.207** | **Auto mode su Bedrock, Vertex AI e Foundry senza opt-in**: non serve piu' `CLAUDE_CODE_ENABLE_AUTO_MODE=1` (disabilitabile con `disableAutoMode` nei settings). Bedrock/Vertex/Claude Platform su AWS passano a **Opus 4.8** come modello default. Fix: freeze del terminale e lag sui tasti con liste/tabelle/code block molto lunghi in streaming; falsi warning di prompt-injection su update di sistema benigni; auto-updater che sovrascriveva script di launcher custom in `~/.local/bin/claude`; dialog di consenso sicurezza mancante su settings managed remoti in run non interattivi (`-p`, SDK). |
 
-<sub>Aggiornato 2026-07-08 via daily what's new. Fonte: [GitHub Releases v2.1.202](https://github.com/anthropics/claude-code/releases/tag/v2.1.202) · [v2.1.203](https://github.com/anthropics/claude-code/releases/tag/v2.1.203) · [v2.1.204](https://github.com/anthropics/claude-code/releases/tag/v2.1.204).</sub>
+<sub>Aggiornato 2026-07-12 via daily what's new. Fonte: [GitHub Releases v2.1.205](https://github.com/anthropics/claude-code/releases/tag/v2.1.205) · [v2.1.206](https://github.com/anthropics/claude-code/releases/tag/v2.1.206) · [v2.1.207](https://github.com/anthropics/claude-code/releases/tag/v2.1.207).</sub>
 
 ---
 

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -9,6 +9,12 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 **Politica di retention**: ultimi 30 giorni. Le entry piu' vecchie sono cancellate (per evitare crescita illimitata del file). La storia completa resta comunque tracciabile via `git log README.md`.
 
+## 2026-07-08
+
+- **Dynamic workflow size** in `/config` (v2.1.202, 6 lug): linea guida small/medium/large su quanti agent Claude tende a usare quando scrive un [dynamic workflow](./docs/24-workflows.md) — indicativa, non un tetto imposto dal runtime. Stessa release: attributi OpenTelemetry `workflow.run_id`/`workflow.name` per ricostruire l'attivita' di un run, e `/review <PR>` torna a single-pass veloce (multi-agent resta su `/code-review <level> <PR#>`). Fonte: [GitHub Releases v2.1.202](https://github.com/anthropics/claude-code/releases/tag/v2.1.202). Doc: [docs/24-workflows.md](./docs/24-workflows.md), [docs/03-slash-commands.md](./docs/03-slash-commands.md), [docs/19-changelog.md](./docs/19-changelog.md).
+
+---
+
 ## 2026-07-06
 
 > Nessuna novita' significativa nelle ultime 24 ore.
@@ -191,12 +197,6 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 ---
 
 ## 2026-06-08
-
-> Nessuna novita' significativa nelle ultime 24 ore.
-
----
-
-## 2026-06-07
 
 > Nessuna novita' significativa nelle ultime 24 ore.
 


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily` ([automation README](../tree/main/automations/daily-whats-new)).

**Nota sul gap**: la routine non ha girato tra il 2026-07-09 e il 2026-07-11 (nessun commit `feat(daily)` in quella finestra). Questo run copre solo le vere novita' delle ultime ~24-36h (v2.1.207, 11 lug) per restare fedele allo scope "ultime 24 ore" della routine, ma ha aggiunto ad addendum anche le versioni non ancora documentate (v2.1.205, v2.1.206) nella tabella storica di `docs/19-changelog.md` per non lasciare buchi nel changelog di riferimento.

## Novita' incluse
- **CLI v2.1.207** (11 lug): auto mode su Bedrock/Vertex/Foundry senza opt-in, default model Opus 4.8 su AWS, fix terminal freeze + falsi warning prompt-injection + auto-updater launcher override.
- **`/doctor` → `/checkup`** (v2.1.206, 10 lug, via [@bcherny](https://x.com/bcherny/status/2074997570317779038)): checkup completo diagnosi+fix di skill/MCP/plugin inutilizzati, CLAUDE.md, hook lenti.

## Verificare:
- [ ] Sezione 'What's new today' nel README aggiornata
- [ ] Sezione precedente (2026-07-08) archiviata in docs/whats-new-archive.md
- [ ] Callout aggiunti coerenti nei doc target (docs/03-slash-commands.md, docs/04-modalita-permessi.md)
- [ ] Addendum v2.1.205/206/207 in docs/19-changelog.md
- [ ] Niente duplicati con ultime 7 entry archive

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQSqgumWGw4euzd39wx2So)_