### PR TITLE
What's new 2026-07-13

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,11 @@
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-07-12)
+## What's new today (2026-07-13)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-- **Browser in-app su Desktop**: Claude Code su Desktop apre un browser integrato, sandboxato, con cui Claude legge documentazione, design e siti esterni, clicca ed interagisce come gia' fa coi dev server locali — sessioni persistenti opzionali, permessi per-sito (Allow once / Always / Deny). Scorciatoia `Ctrl+Shift+B` (Windows) / `Cmd+Shift+B` (macOS). Fonte: [@ClaudeDevs](https://x.com/ClaudeDevs/status/2075635283211772279). Doc: [docs/17-ide-surface.md](./docs/17-ide-surface.md), [docs/19-changelog.md](./docs/19-changelog.md).
-- **`/checkup`** (v2.1.205, 8 lug): nuovo alias di `/doctor` che diventa un vero setup checkup — diagnostica e propone fix per skill/MCP/plugin inutilizzati (in base al costo di context), deduplica `CLAUDE.md` locali contro le versioni committate e segnala hook lenti; riporta i risultati e chiede conferma prima di modificare nulla. Fonte: [GitHub Releases v2.1.205](https://github.com/anthropics/claude-code/releases/tag/v2.1.205). Doc: [docs/03-slash-commands.md](./docs/03-slash-commands.md), [docs/02-cli-installazione.md](./docs/02-cli-installazione.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **Fable 5 incluso nei piani paid + limiti settimanali CC +50%, estesi al 19 lug**: Anthropic proroga per la terza volta l'accesso a Claude Fable 5 senza usage credit su Pro/Max/Team/Enterprise a seat, e mantiene i limiti settimanali di Claude Code alzati del 50% — entrambi validi fino al 19 luglio 2026, 23:59:59 PT. Fonte: [@claudeai](https://x.com/claudeai/status/2076351399999557669). Doc: [docs/05-fast-mode-1m-context.md § 5.7](./docs/05-fast-mode-1m-context.md).
 
 ---
 

--- a/docs/05-fast-mode-1m-context.md
+++ b/docs/05-fast-mode-1m-context.md
@@ -190,6 +190,8 @@ v2.1.170 (9 giugno 2026). `claude-fable-5` e' il primo modello **Mythos-class** 
 ### Disponibilita'
 Generale su Claude API, Claude Platform on AWS, Amazon Bedrock, Vertex AI e Microsoft Foundry (dal 9 giugno 2026).
 
+> **2026-07-13 (auto-update)**: terza proroga dell'accesso a Fable 5 incluso nei piani paid (Pro/Max/Team/Enterprise a seat) senza usage credit, ora fino al 19 luglio 2026 — stessa scadenza per i limiti settimanali di Claude Code alzati del 50%. Fonte: [@claudeai](https://x.com/claudeai/status/2076351399999557669). Vedi anche README "What's new today" del giorno.
+
 ### Relazione con Opus 4.8
 Fable 5 supera Opus 4.8 in capacita'. Se una richiesta viene rifiutata dai classifier di sicurezza, il meccanismo `fallbackModel` puo' riservare automaticamente su Opus 4.8. Il parametro `fallbacks` nell'API gestisce questo caso lato server.
 

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -9,6 +9,13 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 **Politica di retention**: ultimi 30 giorni. Le entry piu' vecchie sono cancellate (per evitare crescita illimitata del file). La storia completa resta comunque tracciabile via `git log README.md`.
 
+## 2026-07-12
+
+- **Browser in-app su Desktop**: Claude Code su Desktop apre un browser integrato, sandboxato, con cui Claude legge documentazione, design e siti esterni, clicca ed interagisce come gia' fa coi dev server locali — sessioni persistenti opzionali, permessi per-sito (Allow once / Always / Deny). Scorciatoia `Ctrl+Shift+B` (Windows) / `Cmd+Shift+B` (macOS). Fonte: [@ClaudeDevs](https://x.com/ClaudeDevs/status/2075635283211772279). Doc: [docs/17-ide-surface.md](./17-ide-surface.md), [docs/19-changelog.md](./19-changelog.md).
+- **`/checkup`** (v2.1.205, 8 lug): nuovo alias di `/doctor` che diventa un vero setup checkup — diagnostica e propone fix per skill/MCP/plugin inutilizzati (in base al costo di context), deduplica `CLAUDE.md` locali contro le versioni committate e segnala hook lenti; riporta i risultati e chiede conferma prima di modificare nulla. Fonte: [GitHub Releases v2.1.205](https://github.com/anthropics/claude-code/releases/tag/v2.1.205). Doc: [docs/03-slash-commands.md](./03-slash-commands.md), [docs/02-cli-installazione.md](./02-cli-installazione.md), [docs/19-changelog.md](./19-changelog.md).
+
+---
+
 ## 2026-07-08
 
 - **Dynamic workflow size** in `/config` (v2.1.202, 6 lug): linea guida small/medium/large su quanti agent Claude tende a usare quando scrive un [dynamic workflow](./24-workflows.md) — indicativa, non un tetto imposto dal runtime. Stessa release: attributi OpenTelemetry `workflow.run_id`/`workflow.name` per ricostruire l'attivita' di un run, e `/review <PR>` torna a single-pass veloce (multi-agent resta su `/code-review <level> <PR#>`). Fonte: [GitHub Releases v2.1.202](https://github.com/anthropics/claude-code/releases/tag/v2.1.202). Doc: [docs/24-workflows.md](./24-workflows.md), [docs/03-slash-commands.md](./03-slash-commands.md), [docs/19-changelog.md](./19-changelog.md).
@@ -193,12 +200,6 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 - **Safe Mode** (`--safe-mode` / `CLAUDE_CODE_SAFE_MODE`, v2.1.169, 8 giu): nuovo flag di avvio disabilita tutte le customizzazioni (CLAUDE.md, plugin, skill, hook, MCP server) — pensato per troubleshooting isolato senza toccare la configurazione permanente. Fonte: [GitHub Releases v2.1.169](https://github.com/anthropics/claude-code/releases/tag/v2.1.169). Doc: [docs/04-modalita-permessi.md](./docs/04-modalita-permessi.md), [docs/18-settings-auth.md](./docs/18-settings-auth.md).
 - **`/cd`** (v2.1.169, 8 giu): nuovo slash command sposta la sessione in una nuova working directory senza rompere il prompt cache — prima si doveva riavviare la sessione. Fonte: [GitHub Releases v2.1.169](https://github.com/anthropics/claude-code/releases/tag/v2.1.169). Doc: [docs/03-slash-commands.md](./docs/03-slash-commands.md).
 - **`disableBundledSkills`** (`CLAUDE_CODE_DISABLE_BUNDLED_SKILLS`, v2.1.169, 8 giu): nuovo setting nasconde le skill bundled e i comandi built-in dal modello — utile per ambienti enterprise che vogliono esporre solo le proprie skill custom. Fonte: [GitHub Releases v2.1.169](https://github.com/anthropics/claude-code/releases/tag/v2.1.169). Doc: [docs/09-skills.md](./docs/09-skills.md), [docs/18-settings-auth.md](./docs/18-settings-auth.md).
-
----
-
-## 2026-06-08
-
-> Nessuna novita' significativa nelle ultime 24 ore.
 
 ---
 


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily` ([automation README](../tree/main/automations/daily-whats-new)).

## Novita' trovate

- Proroga (terza) dell'accesso incluso a Claude Fable 5 su piani paid e dei limiti settimanali Claude Code +50%, ora fino al 19 luglio 2026 — [@claudeai](https://x.com/claudeai/status/2076351399999557669).

Nessuna nuova versione CLI rilasciata nelle ultime 24h (ultima resta v2.1.207, gia' coperta). Changelog ufficiale, GitHub releases, Anthropic news e i restanti account X monitorati non riportano altre novita' Claude Code datate 12-13 luglio 2026.

Verificare:
- [x] Sezione 'What's new today' nel README aggiornata
- [x] Sezione precedente (2026-07-12) archiviata in docs/whats-new-archive.md
- [x] Callout aggiunto in docs/05-fast-mode-1m-context.md § 5.7 (coerente con l'unica voce della TLDR)
- [x] Nessun duplicato con le ultime 7 entry archive

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnpGkR739GHJuyj8BCGmvw)_