### PR TITLE
What's new 2026-07-14

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
 # Claude Code — Guida (5 maggio 2026)
 
 > Reference completa di Claude Code (CLI, IDE, Web, Desktop, SDK) curata da [Boosha AI](https://boosha.it).
-> Ultimo aggiornamento: **13 luglio 2026, 07:00 CEST**.
-> Versione CLI di riferimento: **v2.1.207** · Modello default **Sonnet 5** · Premium **Fable 5 / Opus 4.8 + xhigh** (Max plan).
+> Ultimo aggiornamento: **14 luglio 2026, 07:00 CEST**.
+> Versione CLI di riferimento: **v2.1.208** · Modello default **Sonnet 5** · Premium **Fable 5 / Opus 4.8 + xhigh** (Max plan).
 
 > 🆕 **Novita' aprile 2026 (F4)**: integrato il case study **Kora team Every** (compound engineering applicato), **filosofia vibe-to-agentic**, **workflow operativi storici** (worktree script, Friday refactor, bug investigation), **Conductor + Ralph community pattern**. Nuova [Quick Start 60 min](./docs/QUICKSTART.md) + 8 [template `.claude/` per persona](./examples/personas/).
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-07-13)
+## What's new today (2026-07-14)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-> Nessuna novita' significativa nelle ultime 24 ore. Prossimo aggiornamento domani 07:00.
+- **CLI v2.1.208** introduce lo **screen reader mode** nativo (`claude --ax-screen-reader` / `axScreenReader`), rendering plain-text opt-in per utenti di screen reader. Fonte: [GitHub Releases v2.1.208](https://github.com/anthropics/claude-code/releases/tag/v2.1.208). Vedi [docs/18 § TUI/display](./docs/18-settings-auth.md) e [docs/19 § changelog](./docs/19-changelog.md).
+- **`vimInsertModeRemaps`** (v2.1.208): nuova setting mappa sequenze insert-mode a due tasti (es. `jj` → Escape) in vim mode, senza plugin esterni. Fonte: [GitHub Releases v2.1.208](https://github.com/anthropics/claude-code/releases/tag/v2.1.208). Vedi [docs/20 § Vim mode avanzato](./docs/20-tips-best-practices.md).
+- **`CLAUDE_CODE_PROCESS_WRAPPER`** (v2.1.208): agent view e background service instradano ogni self-spawn attraverso un eseguibile wrapper richiesto — supporto per launcher aziendali. Fonte: [GitHub Releases v2.1.208](https://github.com/anthropics/claude-code/releases/tag/v2.1.208). Vedi [docs/18 § Advanced](./docs/18-settings-auth.md).
+- **Giro affidabilita' v2.1.208**: transcript di sessione fino a 79x piu' leggeri in sessioni edit-heavy, tool round fino a 7x piu' veloci con molti server MCP, chiusi diversi memory leak (MCP stdio, documenti LSP, hook async), fix crash su GOAWAY HTTP/2 e falso reset del context window dopo auto-update. Fonte: [GitHub Releases v2.1.208](https://github.com/anthropics/claude-code/releases/tag/v2.1.208). Vedi [docs/19 § changelog](./docs/19-changelog.md).
 
 ---
 

--- a/docs/18-settings-auth.md
+++ b/docs/18-settings-auth.md
@@ -116,6 +116,8 @@ Vedi [4 Modalita' permessi § 4.4](./04-modalita-permessi.md#sandbox).
 
 <sub>Aggiornato 2026-06-18 via daily what's new. Fonte: [GitHub Releases v2.1.181](https://github.com/anthropics/claude-code/releases/tag/v2.1.181).</sub>
 
+> **2026-07-14 (auto-update)**: nuovo **screen reader mode** — rendering plain-text opt-in per utenti di screen reader. Attivazione: flag `claude --ax-screen-reader`, env var `CLAUDE_AX_SCREEN_READER=1` o `"axScreenReader": true` in settings. Fonte: [GitHub Releases v2.1.208](https://github.com/anthropics/claude-code/releases/tag/v2.1.208). Vedi anche README "What's new today" del giorno.
+
 ### Memory
 - `autoMemoryEnabled`, `autoMemoryDirectory`, `cleanupPeriodDays`, `plansDirectory`
 
@@ -143,6 +145,8 @@ Vedi [4 Modalita' permessi § 4.4](./04-modalita-permessi.md#sandbox).
 > - Toggle per-modello in `/model` (settings persistente per sessione)
 >
 > I provider third-party (Bedrock, Vertex, Foundry) rimangono invariati — la disabilitazione si applica solo alla Claude API diretta.
+
+> **2026-07-14 (auto-update)**: nuova env var **`CLAUDE_CODE_PROCESS_WRAPPER`** — agent view e background service instradano ogni self-spawn di Claude Code attraverso un eseguibile wrapper richiesto, per rispettare launcher aziendali (compliance enterprise su processi figli). Fonte: [GitHub Releases v2.1.208](https://github.com/anthropics/claude-code/releases/tag/v2.1.208). Vedi anche README "What's new today" del giorno.
 
 ### Worktree
 - `worktree.symlinkDirectories`, `worktree.sparsePaths`

--- a/docs/19-changelog.md
+++ b/docs/19-changelog.md
@@ -3,7 +3,7 @@
 > 📍 [README](../README.md) → [Riferimenti](../README.md#riferimenti) → **19 Changelog**
 > 📚 Riferimento · 🟢 Beginner-friendly
 
-Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (11 luglio 2026, v2.1.207). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
+Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (14 luglio 2026, v2.1.208). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
 
 ## Cosa e' concettualmente
 
@@ -541,8 +541,11 @@ Vedi anche [@bcherny](https://x.com/bcherny/status/2047375800945783056).
 | 9 lug 2026 | v2.1.206 | Directory path suggestion su `/cd` (come `/add-dir`). `/doctor`/`/checkup`: check per il trimming dei `CLAUDE.md` committati. `/commit-push-pr` auto-allow su `git push` verso il remote configurato (non solo `origin`). `EnterWorktree` chiede conferma prima di entrare in un worktree fuori da `.claude/worktrees/`. Background agent aggiornati subito dopo l'update, non al primo attach. Fix: `/model`, MCP timeout per-server, OAuth MCP re-auth, `claude rm`/`claude agents` roster desync. |
 | 10 lug 2026 | — | **Browser in-app su Desktop**: Claude Code su Desktop apre un browser integrato sandboxato — Claude legge documentazione, design e siti esterni, clicca ed interagisce come coi dev server locali. Sessioni persistenti opzionali, permessi per-sito (Allow once / Always / Deny), scorciatoia `Ctrl+Shift+B` / `Cmd+Shift+B`. [@ClaudeDevs](https://x.com/ClaudeDevs/status/2075635283211772279). Vedi [17.3 Desktop app](./17-ide-surface.md#173-desktop-app-endesktop). |
 | 11 lug 2026 | v2.1.207 | Auto mode disponibile senza opt-in `CLAUDE_CODE_ENABLE_AUTO_MODE` su Bedrock/Vertex/Foundry (`disableAutoMode` per disattivare). Bedrock/Vertex/Claude Platform su AWS passano a Opus 4.8 come default. Fix shell-injection: `${user_config.*}` non piu' interpolato in hook/monitor/MCP headersHelper shell-form. Fix: freeze terminale su risposte molto lunghe, consenso remote settings non mostrato in run non interattivi, falsi warning prompt-injection su aggiornamenti di sistema. |
+| 14 lug 2026 | **v2.1.208** | **Screen reader mode**: rendering plain-text opt-in (`claude --ax-screen-reader`, `CLAUDE_AX_SCREEN_READER=1` o `"axScreenReader": true`). **`vimInsertModeRemaps`**: mappa sequenze insert-mode a due tasti (es. `jj` → Escape) in vim mode. **`CLAUDE_CODE_PROCESS_WRAPPER`**: agent view e background service instradano ogni self-spawn attraverso un eseguibile wrapper richiesto da launcher aziendali. Mouse-click su multi-select menu e righe "Other" in fullscreen. Giro affidabilita' importante: transcript di sessione fino a 79x piu' leggeri in sessioni edit-heavy, tool round fino a 7x piu' veloci con molti server MCP, chiusi diversi memory leak (stderr MCP stdio, documenti LSP, hook async, cache lettura file), fix crash su GOAWAY HTTP/2 e falso reset del context window dopo auto-update. |
 
 <sub>Aggiornato 2026-07-12 via daily what's new. Fonte: [GitHub Releases v2.1.205](https://github.com/anthropics/claude-code/releases/tag/v2.1.205) · [v2.1.206](https://github.com/anthropics/claude-code/releases/tag/v2.1.206) · [v2.1.207](https://github.com/anthropics/claude-code/releases/tag/v2.1.207) · [@ClaudeDevs](https://x.com/ClaudeDevs/status/2075635283211772279).</sub>
+
+<sub>Aggiornato 2026-07-14 via daily what's new. Fonte: [GitHub Releases v2.1.208](https://github.com/anthropics/claude-code/releases/tag/v2.1.208).</sub>
 
 ---
 

--- a/docs/20-tips-best-practices.md
+++ b/docs/20-tips-best-practices.md
@@ -324,6 +324,8 @@ Estratte dalla cheat sheet community [bhancockio/claude-code-cheat-sheet](https:
 - **`Ctrl+T`**: apre il pannello Tasks/todos correnti senza interrompere il flusso.
 - **`Ctrl+O`**: apre il pannello Thinking per vedere il ragionamento extended thinking in tempo reale.
 - **Vim mode avanzato**: oltre a `i/a/o`, supportati `dw/de/db/dd/D` (delete), `cw/ce/cb/cc/C` (change), `.` (ripeti ultima azione). Attivazione globale: `claude config set -g vimMode true`. Visual mode `v`/`V` da v2.1.118.
+
+  > **2026-07-14 (auto-update)**: nuova setting **`vimInsertModeRemaps`** mappa sequenze insert-mode a due tasti (es. `jj` → Escape) in vim mode, senza plugin esterni. Fonte: [GitHub Releases v2.1.208](https://github.com/anthropics/claude-code/releases/tag/v2.1.208). Vedi anche README "What's new today" del giorno.
 - **Output style "Explanatory"** combinato con `Ctrl+O`: vedi sia il "perche'" stilistico sia il thinking grezzo — ottimo per onboarding su codebase nuove.
 - **Custom keybindings VS Code/Cursor** per terminale: `Cmd+Shift+C` apre nuovo terminale come tab editor, `Cmd+Shift+R` rinomina, `Cmd+Shift+[ / ]` naviga tra terminali. Config in `keybindings.json`.
 

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -9,6 +9,12 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 **Politica di retention**: ultimi 30 giorni. Le entry piu' vecchie sono cancellate (per evitare crescita illimitata del file). La storia completa resta comunque tracciabile via `git log README.md`.
 
+## 2026-07-13
+
+> Nessuna novita' significativa nelle ultime 24 ore.
+
+---
+
 ## 2026-07-12
 
 - **Browser in-app su Desktop**: Claude Code su Desktop apre un browser integrato, sandboxato, con cui Claude legge documentazione, design e siti esterni, clicca ed interagisce come gia' fa coi dev server locali — sessioni persistenti opzionali, permessi per-sito (Allow once / Always / Deny). Scorciatoia `Ctrl+Shift+B` (Windows) / `Cmd+Shift+B` (macOS). Fonte: [@ClaudeDevs](https://x.com/ClaudeDevs/status/2075635283211772279). Doc: [docs/17-ide-surface.md](./17-ide-surface.md), [docs/19-changelog.md](./19-changelog.md).


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily` ([automation README](../tree/main/automations/daily-whats-new)).

## Novita' rilevata

Rilascio **CLI v2.1.208** (14 lug 2026) — GitHub Releases: https://github.com/anthropics/claude-code/releases/tag/v2.1.208

- Screen reader mode nativo (`--ax-screen-reader` / `axScreenReader`)
- `vimInsertModeRemaps` (remap sequenze insert-mode a due tasti in vim mode)
- `CLAUDE_CODE_PROCESS_WRAPPER` (launcher aziendali per self-spawn)
- Giro affidabilita': transcript fino a 79x piu' leggeri, tool round fino a 7x piu' veloci, chiusi diversi memory leak

Nessun'altra novita' confermata nelle ultime 24h da Anthropic blog o post X dei team (@bcherny, @_catwu, @noahzweben, @trq212, @claudeai, @ClaudeDevs, @alistaiir, @ClaudeCodeLog) — ricerca X via WebSearch (WebFetch diretto su x.com non disponibile in questo ambiente).

## Verificare

- [x] Sezione 'What's new today' nel README aggiornata
- [x] Sezione precedente (2026-07-13, nessuna novita') archiviata in docs/whats-new-archive.md
- [x] Callout aggiunti coerenti con i doc target (docs/18, docs/19, docs/20)
- [x] Niente duplicati con ultime 7 entry archive

Auto-merge non attivo per default. Mergiare manualmente se OK.

## Nota sul branch

Questo ambiente ha assegnato la sessione al branch `claude/peaceful-volta-nghmr8` (anziche' `whats-new/2026-07-14` come da convenzione della routine) — vincolo del setup del run corrente, non uno scostamento intenzionale dalla convenzione.

---
_Generated by [Claude Code](https://claude.ai/code/session_018YDMUGRQn52cwxULqF5yZr)_