### PR TITLE
What's new 2026-07-19

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 # Claude Code — Guida (5 maggio 2026)
 
 > Reference completa di Claude Code (CLI, IDE, Web, Desktop, SDK) curata da [Boosha AI](https://boosha.it).
-> Ultimo aggiornamento: **18 luglio 2026, 07:00 CEST**.
-> Versione CLI di riferimento: **v2.1.214** · Modello default **Sonnet 5** · Premium **Fable 5 / Opus 4.8 + xhigh** (Max plan).
+> Ultimo aggiornamento: **19 luglio 2026, 07:00 CEST**.
+> Versione CLI di riferimento: **v2.1.215** · Modello default **Sonnet 5** · Premium **Fable 5 / Opus 4.8 + xhigh** (Max plan).
 
 > 🆕 **Novita' aprile 2026 (F4)**: integrato il case study **Kora team Every** (compound engineering applicato), **filosofia vibe-to-agentic**, **workflow operativi storici** (worktree script, Friday refactor, bug investigation), **Conductor + Ralph community pattern**. Nuova [Quick Start 60 min](./docs/QUICKSTART.md) + 8 [template `.claude/` per persona](./examples/personas/).
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-07-18)
+## What's new today (2026-07-19)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-- **`/fork` → sessione background + `/subtask`** (v2.1.212, 17 lug): `/fork` non spawna piu' un subagent in-sessione ma copia l'intera conversazione in una nuova sessione background (riga separata in `claude agents`), lasciando libero il thread principale; il vecchio comportamento (subagent dentro la sessione corrente) e' ora `/subtask`. Stessa release: tetti di sicurezza default (200 WebSearch, 200 subagent spawn per sessione) e `/resume` con picker delle sessioni passate, incluse quelle cancellate. Fonte: [GitHub Releases v2.1.212](https://github.com/anthropics/claude-code/releases/tag/v2.1.212). Doc: [docs/08-subagents.md](./docs/08-subagents.md), [docs/03-slash-commands.md](./docs/03-slash-commands.md), [docs/19-changelog.md](./docs/19-changelog.md).
-- **Tool `EndConversation`** (v2.1.214, 18 lug): nuovo tool primitivo che permette a Claude di terminare autonomamente una conversazione con utenti fortemente abusivi o tentativi di jailbreak, affiancandosi a Monitor e AskUserQuestion nella cassetta degli attrezzi built-in dell'agent loop. Fonte: [GitHub Releases v2.1.214](https://github.com/anthropics/claude-code/releases/tag/v2.1.214). Doc: [docs/16-headless-agent-sdk.md](./docs/16-headless-agent-sdk.md), [docs/04-modalita-permessi.md](./docs/04-modalita-permessi.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **`/verify` e `/code-review` non piu' auto-invocati** (v2.1.215, 19 lug): Claude smette di eseguire in autonomia le skill `/verify` e `/code-review` durante il lavoro — vanno richiamate esplicitamente quando servono. Fonte: [GitHub Releases v2.1.215](https://github.com/anthropics/claude-code/releases/tag/v2.1.215). Doc: [docs/03-slash-commands.md](./docs/03-slash-commands.md), [docs/19-changelog.md](./docs/19-changelog.md).
 
 ---
 

--- a/docs/03-slash-commands.md
+++ b/docs/03-slash-commands.md
@@ -5,6 +5,8 @@
 
 Riferimento completo dei comandi `/` built-in e bundled skills al v2.1.183. Type `/` in sessione per vederli filtrati. Convenzione: **[Skill]** = bundled skill (prompt-based, anche auto-invocabile da Claude); altri = built-in CLI.
 
+> **2026-07-19 (auto-update)**: da v2.1.215 Claude non esegue piu' in autonomia le skill `/verify` e `/code-review` — vanno richiamate esplicitamente quando servono. Fonte: [GitHub Releases v2.1.215](https://github.com/anthropics/claude-code/releases/tag/v2.1.215). Vedi anche README "What's new today" del giorno.
+
 ## Cosa e' concettualmente
 
 > Gli slash commands sono il **vocabolario condiviso** tra utente e agent. Sono shortcut a workflow ricorrenti: ognuno e' un'intent capture pre-codificato. I bundled skills (`/loop`, `/simplify`, `/batch`, `/debug`) sono skill markdown auto-installate; i built-in (`/plan`, `/compact`, `/effort`) sono comandi nativi del CLI.

--- a/docs/19-changelog.md
+++ b/docs/19-changelog.md
@@ -3,7 +3,9 @@
 > 📍 [README](../README.md) → [Riferimenti](../README.md#riferimenti) → **19 Changelog**
 > 📚 Riferimento · 🟢 Beginner-friendly
 
-Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (18 luglio 2026, v2.1.214). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
+Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (19 luglio 2026, v2.1.215). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
+
+> **2026-07-19 (auto-update)**: v2.1.215 rimuove l'auto-invocazione delle skill `/verify` e `/code-review` — ora vanno richiamate esplicitamente. Fonte: [GitHub Releases v2.1.215](https://github.com/anthropics/claude-code/releases/tag/v2.1.215). Vedi anche README "What's new today" del giorno.
 
 ## Cosa e' concettualmente
 
@@ -545,9 +547,11 @@ Vedi anche [@bcherny](https://x.com/bcherny/status/2047375800945783056).
 | 15 lug 2026 | v2.1.211 | Flag `--forward-subagent-text` + env `CLAUDE_CODE_FORWARD_SUBAGENT_TEXT` per output `stream-json`. Hardening dell'Agent tool contro prompt injection indiretta. Fix: permission preview inoltrate a canali chat non neutralizzavano caratteri bidirectional-override, auto mode che scavalcava la decisione `ask` degli hook PreToolUse su Bash non-sandboxato, sessioni parallele disconnesse simultaneamente dopo sleep/wake. |
 | 17 lug 2026 | **v2.1.212** | **`/fork` → sessione background + `/subtask`**: `/fork` copia ora l'intera conversazione in una nuova sessione background (riga propria in `claude agents`) invece di spawnare un subagent in-sessione — quel comportamento e' il nuovo `/subtask`. Aggiunti tetti di sicurezza per-sessione: WebSearch (default 200, `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION`) e subagent spawn (default 200, `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION`); chiamate MCP oltre 2 minuti passano automaticamente in background. `claude auto-mode reset` per ripristinare la config auto mode di default. `/resume` mostra un picker delle sessioni passate, incluse quelle cancellate. Fix: plan mode che eseguiva comandi Bash file-modifying senza prompt di permesso. |
 | 18 lug 2026 | **v2.1.214** | **Tool `EndConversation`**: nuovo tool primitivo che permette a Claude di terminare autonomamente conversazioni con utenti fortemente abusivi o tentativi di jailbreak ripetuti. Aggiunto heartbeat periodico di progresso per tool call di lunga durata e timestamp ISO `modified` nel frontmatter dei memory file. Fix di sicurezza: regole di permesso a singolo segmento tipo `Edit(src/**)` che auto-approvavano scritture in directory annidate ovunque nel repo (ora solo `<cwd>/dir`), bypass dei permission check su Windows PowerShell 5.1, comandi Bash oltre 10.000 caratteri che bypassavano il prompt di conferma. |
+| 19 lug 2026 | **v2.1.215** | Claude non esegue piu' in autonomia le skill `/verify` e `/code-review` — vanno richiamate esplicitamente quando servono. |
 
 <sub>Aggiornato 2026-07-12 via daily what's new. Fonte: [GitHub Releases v2.1.205](https://github.com/anthropics/claude-code/releases/tag/v2.1.205) · [v2.1.206](https://github.com/anthropics/claude-code/releases/tag/v2.1.206) · [v2.1.207](https://github.com/anthropics/claude-code/releases/tag/v2.1.207) · [@ClaudeDevs](https://x.com/ClaudeDevs/status/2075635283211772279).</sub>
 <sub>Aggiornato 2026-07-18 via daily what's new. Fonte: [GitHub Releases v2.1.210](https://github.com/anthropics/claude-code/releases/tag/v2.1.210) · [v2.1.211](https://github.com/anthropics/claude-code/releases/tag/v2.1.211) · [v2.1.212](https://github.com/anthropics/claude-code/releases/tag/v2.1.212) · [v2.1.214](https://github.com/anthropics/claude-code/releases/tag/v2.1.214).</sub>
+<sub>Aggiornato 2026-07-19 via daily what's new. Fonte: [GitHub Releases v2.1.215](https://github.com/anthropics/claude-code/releases/tag/v2.1.215).</sub>
 
 ---
 

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -9,6 +9,19 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 **Politica di retention**: ultimi 30 giorni. Le entry piu' vecchie sono cancellate (per evitare crescita illimitata del file). La storia completa resta comunque tracciabile via `git log README.md`.
 
+## 2026-07-18
+
+- **`/fork` → sessione background + `/subtask`** (v2.1.212, 17 lug): `/fork` non spawna piu' un subagent in-sessione ma copia l'intera conversazione in una nuova sessione background (riga separata in `claude agents`), lasciando libero il thread principale; il vecchio comportamento (subagent dentro la sessione corrente) e' ora `/subtask`. Stessa release: tetti di sicurezza default (200 WebSearch, 200 subagent spawn per sessione) e `/resume` con picker delle sessioni passate, incluse quelle cancellate. Fonte: [GitHub Releases v2.1.212](https://github.com/anthropics/claude-code/releases/tag/v2.1.212). Doc: [docs/08-subagents.md](./docs/08-subagents.md), [docs/03-slash-commands.md](./docs/03-slash-commands.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **Tool `EndConversation`** (v2.1.214, 18 lug): nuovo tool primitivo che permette a Claude di terminare autonomamente una conversazione con utenti fortemente abusivi o tentativi di jailbreak, affiancandosi a Monitor e AskUserQuestion nella cassetta degli attrezzi built-in dell'agent loop. Fonte: [GitHub Releases v2.1.214](https://github.com/anthropics/claude-code/releases/tag/v2.1.214). Doc: [docs/16-headless-agent-sdk.md](./docs/16-headless-agent-sdk.md), [docs/04-modalita-permessi.md](./docs/04-modalita-permessi.md), [docs/19-changelog.md](./docs/19-changelog.md).
+
+---
+
+## 2026-07-14
+
+> Nessuna novita' significativa nelle ultime 24 ore.
+
+---
+
 ## 2026-07-13
 
 > Nessuna novita' significativa nelle ultime 24 ore.
@@ -186,18 +199,6 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 - **Usage attribution per-skill/agent/plugin** (v2.1.174, 12 giu): il dialog "Account & usage" mostra ora breakdowns granulari per skill, agent, plugin e server MCP, oltre a cache misses e long context — utile per analizzare i costi nei workflow agentic complessi. Fonte: [GitHub Releases v2.1.174](https://github.com/anthropics/claude-code/releases/tag/v2.1.174). Doc: [docs/08-subagents.md](./docs/08-subagents.md), [docs/19-changelog.md](./docs/19-changelog.md).
 - **`enforceAvailableModels`** (v2.1.175, 12 giu): nuova opzione managed settings rende strict l'allowlist `availableModels` — il Default model e' ora vincolato dalla lista gestita e user/project settings non possono espandere i modelli consentiti dall'enterprise. Fonte: [GitHub Releases v2.1.175](https://github.com/anthropics/claude-code/releases/tag/v2.1.175). Doc: [docs/18-settings-auth.md](./docs/18-settings-auth.md), [docs/19-changelog.md](./docs/19-changelog.md).
-
----
-
-## 2026-06-11
-
-- **Sub-agenti annidati fino a 5 livelli** (v2.1.172, 10 giu): i sub-agenti possono ora lanciare a loro volta sub-agenti, con gerarchia profonda fino a 5 livelli — ogni livello riceve un context window fresco e restituisce solo un summary al padre. Abilita l'orchestrazione di task complessi senza saturare il context del main agent. Fonte: [GitHub Releases v2.1.172](https://github.com/anthropics/claude-code/releases/tag/v2.1.172). Doc: [docs/08-subagents.md](./docs/08-subagents.md), [docs/19-changelog.md](./docs/19-changelog.md).
-
----
-
-## 2026-07-14
-
-> Nessuna novita' significativa nelle ultime 24 ore.
 
 ---
 


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily` ([automation README](../tree/main/automations/daily-whats-new)).

## Novita' rilevata

- **`/verify` e `/code-review` non piu' auto-invocati** (v2.1.215, 19 lug): Claude smette di eseguire in autonomia le skill `/verify` e `/code-review` durante il lavoro — vanno richiamate esplicitamente quando servono. Fonte: [GitHub Releases v2.1.215](https://github.com/anthropics/claude-code/releases/tag/v2.1.215).

Nessun'altra novita' rilevante trovata nelle ultime 24 ore su changelog ufficiale, blog Anthropic, GitHub releases e post X del team (nessun post datato oggi dai profili monitorati).

Verificare:
- [x] Sezione 'What's new today' nel README aggiornata
- [x] Sezione precedente (2026-07-18) archiviata in docs/whats-new-archive.md
- [x] Callout aggiunti coerenti con i doc target (docs/19-changelog.md, docs/03-slash-commands.md)
- [x] Niente duplicati con ultime 7 entry archive
- [x] Retention archive: sistemata anche una entry `2026-07-14` fuori ordine cronologico presente nel file, e rimossa la entry piu' vecchia (2026-06-11) per rispettare il limite di 30 giorni

Auto-merge non attivo per default. Mergiare manualmente se OK.

Nota: questa sessione era vincolata a sviluppare sul branch `claude/peaceful-volta-9jakxc` (designato dall'harness) invece del branch `whats-new/2026-07-19` indicato nelle istruzioni della routine, per rispettare il vincolo "mai pushare su un branch diverso senza permesso esplicito".

---
_Generated by [Claude Code](https://claude.ai/code/session_01MP2sw2L9GTvguzFaWQWrmq)_