### PR TITLE
What's new 2026-07-20

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # Claude Code — Guida (5 maggio 2026)
 
 > Reference completa di Claude Code (CLI, IDE, Web, Desktop, SDK) curata da [Boosha AI](https://boosha.it).
-> Ultimo aggiornamento: **19 luglio 2026, 07:00 CEST**.
+> Ultimo aggiornamento: **20 luglio 2026, 07:00 CEST**.
 > Versione CLI di riferimento: **v2.1.215** · Modello default **Sonnet 5** · Premium **Fable 5 / Opus 4.8 + xhigh** (Max plan).
 
 > 🆕 **Novita' aprile 2026 (F4)**: integrato il case study **Kora team Every** (compound engineering applicato), **filosofia vibe-to-agentic**, **workflow operativi storici** (worktree script, Friday refactor, bug investigation), **Conductor + Ralph community pattern**. Nuova [Quick Start 60 min](./docs/QUICKSTART.md) + 8 [template `.claude/` per persona](./examples/personas/).
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-07-19)
+## What's new today (2026-07-20)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-- **`/verify` e `/code-review` non piu' auto-invocate** (v2.1.215, 19 lug): Claude non lancia piu' di propria iniziativa le skill `/verify` e `/code-review` a fine task — vanno invocate esplicitamente quando servono. Riduce le review "a sorpresa" non richieste dall'utente. Fonte: [GitHub Releases v2.1.215](https://github.com/anthropics/claude-code/releases/tag/v2.1.215). Doc: [docs/09-skills.md](./docs/09-skills.md), [docs/03-slash-commands.md](./docs/03-slash-commands.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **Claude Fable 5 diventa permanente su Max e Team Premium** (dal 20 lug): Fable 5 entra stabilmente nei piani Max e Team Premium al 50% dei limiti di utilizzo, dopo mesi di rollout progressivo per capacita' limitata. Pro e Team Standard restano su crediti a consumo, con un credito una tantum di $100. Fonte: [@claudeai](https://x.com/claudeai/status/2078302415804379218) · [@trq212](https://x.com/trq212/status/2078514180051906864). Vedi [docs/05 § 5.7 Claude Fable 5](./docs/05-fast-mode-1m-context.md).
+- **Limiti settimanali Claude Code +50% estesi fino al 19 agosto**: Anthropic mantiene i limiti di utilizzo settimanali innalzati del 50% per tutti gli utenti Pro, Max, Team e Enterprise seat-based, prorogando l'estensione precedente. Fonte: [@ClaudeDevs](https://x.com/ClaudeDevs/status/2078511173759324328). Vedi [docs/18 § Login con subscription](./docs/18-settings-auth.md).
 
 ---
 

--- a/docs/05-fast-mode-1m-context.md
+++ b/docs/05-fast-mode-1m-context.md
@@ -171,6 +171,8 @@ Opus 4.7 rimane disponibile via `/model claude-opus-4-7` o `/effort` manuale. Pe
 ### Annunciato
 v2.1.170 (9 giugno 2026). `claude-fable-5` e' il primo modello **Mythos-class** di Anthropic disponibile pubblicamente — prestazioni superiori a qualsiasi modello precedentemente rilasciato al pubblico, ottimizzato per reasoning profondo e lavoro agentico di lunga durata.
 
+> **2026-07-20 (auto-update)**: Fable 5 diventa permanente su Max e Team Premium (50% dei limiti di utilizzo); Pro e Team Standard restano su crediti a consumo con un credito una tantum di $100. Fonte: [@claudeai](https://x.com/claudeai/status/2078302415804379218). Vedi anche README "What's new today" del giorno.
+
 ### Come si usa in Claude Code
 ```bash
 /model claude-fable-5

--- a/docs/18-settings-auth.md
+++ b/docs/18-settings-auth.md
@@ -323,6 +323,8 @@ La scelta tra **subscription OAuth** (Claude Pro/Max/Team/Enterprise) e **API ke
 
 > Fonte: [`/en/authentication`](https://code.claude.com/docs/en/authentication).
 
+> **2026-07-20 (auto-update)**: i limiti settimanali di utilizzo Claude Code restano innalzati del 50% fino al 19 agosto per tutti gli utenti Pro, Max, Team e Enterprise seat-based. Fonte: [@ClaudeDevs](https://x.com/ClaudeDevs/status/2078511173759324328). Vedi anche README "What's new today" del giorno.
+
 ---
 
 ## 18.6 Claude for Teams / Enterprise

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -9,6 +9,12 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 **Politica di retention**: ultimi 30 giorni. Le entry piu' vecchie sono cancellate (per evitare crescita illimitata del file). La storia completa resta comunque tracciabile via `git log README.md`.
 
+## 2026-07-19
+
+- **`/verify` e `/code-review` non piu' auto-invocate** (v2.1.215, 19 lug): Claude non lancia piu' di propria iniziativa le skill `/verify` e `/code-review` a fine task — vanno invocate esplicitamente quando servono. Riduce le review "a sorpresa" non richieste dall'utente. Fonte: [GitHub Releases v2.1.215](https://github.com/anthropics/claude-code/releases/tag/v2.1.215). Doc: [docs/09-skills.md](./09-skills.md), [docs/03-slash-commands.md](./03-slash-commands.md), [docs/19-changelog.md](./19-changelog.md).
+
+---
+
 ## 2026-07-18
 
 - **`/fork` → sessione background + `/subtask`** (v2.1.212, 17 lug): `/fork` non spawna piu' un subagent in-sessione ma copia l'intera conversazione in una nuova sessione background (riga separata in `claude agents`), lasciando libero il thread principale; il vecchio comportamento (subagent dentro la sessione corrente) e' ora `/subtask`. Stessa release: tetti di sicurezza default (200 WebSearch, 200 subagent spawn per sessione) e `/resume` con picker delle sessioni passate, incluse quelle cancellate. Fonte: [GitHub Releases v2.1.212](https://github.com/anthropics/claude-code/releases/tag/v2.1.212). Doc: [docs/08-subagents.md](./08-subagents.md), [docs/03-slash-commands.md](./03-slash-commands.md), [docs/19-changelog.md](./19-changelog.md).
@@ -186,13 +192,6 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 ## 2026-06-13
 
 > Nessuna novita' significativa nelle ultime 24 ore.
-
----
-
-## 2026-06-12
-
-- **Usage attribution per-skill/agent/plugin** (v2.1.174, 12 giu): il dialog "Account & usage" mostra ora breakdowns granulari per skill, agent, plugin e server MCP, oltre a cache misses e long context — utile per analizzare i costi nei workflow agentic complessi. Fonte: [GitHub Releases v2.1.174](https://github.com/anthropics/claude-code/releases/tag/v2.1.174). Doc: [docs/08-subagents.md](./docs/08-subagents.md), [docs/19-changelog.md](./docs/19-changelog.md).
-- **`enforceAvailableModels`** (v2.1.175, 12 giu): nuova opzione managed settings rende strict l'allowlist `availableModels` — il Default model e' ora vincolato dalla lista gestita e user/project settings non possono espandere i modelli consentiti dall'enterprise. Fonte: [GitHub Releases v2.1.175](https://github.com/anthropics/claude-code/releases/tag/v2.1.175). Doc: [docs/18-settings-auth.md](./docs/18-settings-auth.md), [docs/19-changelog.md](./docs/19-changelog.md).
 
 ---
 


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily`.

## Novita' di oggi (2026-07-20)

- **Claude Fable 5 diventa permanente su Max e Team Premium** (50% dei limiti), Pro/Team Standard su crediti + $100 one-time. Fonte: [@claudeai](https://x.com/claudeai/status/2078302415804379218) · [@trq212](https://x.com/trq212/status/2078514180051906864).
- **Limiti settimanali Claude Code +50% estesi fino al 19 agosto** per Pro/Max/Team/Enterprise seat-based. Fonte: [@ClaudeDevs](https://x.com/ClaudeDevs/status/2078511173759324328).

Nessuna nuova versione CLI rilasciata nelle ultime 24h (l'ultima resta v2.1.215, 19 lug, gia' coperta ieri) — `docs/19-changelog.md` non modificato.

**Nota fonti**: il changelog ufficiale e GitHub Releases non riportano novita' oltre v2.1.215. Le due voci sopra vengono da annunci X del team Anthropic (@claudeai, @ClaudeDevs, @trq212) pubblicati il 18-19/07 con entrata in vigore effettiva oggi 20/07 — inclusi comunque per rilevanza al giorno corrente. Il fetch diretto di anthropic.com/news e di alcuni URL x.com ha incontrato errori (403/paywall); i contenuti sono stati recuperati via WebSearch.

Verificare:
- [ ] Sezione 'What's new today' nel README aggiornata
- [ ] Sezione precedente (19 lug) archiviata in docs/whats-new-archive.md
- [ ] Callout aggiunti coerenti nei doc target (docs/05, docs/18)
- [ ] Niente duplicati con ultime 7 entry archive

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5B3gdxptq3HKbCutcMWTM)_