### PR TITLE
What's new 2026-07-23

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-07-19)
+## What's new today (2026-07-23)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-- **`/verify` e `/code-review` non piu' auto-invocate** (v2.1.215, 19 lug): Claude non lancia piu' di propria iniziativa le skill `/verify` e `/code-review` a fine task — vanno invocate esplicitamente quando servono. Riduce le review "a sorpresa" non richieste dall'utente. Fonte: [GitHub Releases v2.1.215](https://github.com/anthropics/claude-code/releases/tag/v2.1.215). Doc: [docs/09-skills.md](./docs/09-skills.md), [docs/03-slash-commands.md](./docs/03-slash-commands.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **CLI v2.1.218** (22 lug): `/code-review` gira ora come subagent in background e non riempie piu' la conversazione principale; fix corruzione path Windows con segmenti `\u`-prefixed; agent view segnala "Needs input" per sessioni in attesa di sandbox/MCP/settings. Fonte: [GitHub Releases v2.1.218](https://github.com/anthropics/claude-code/releases/tag/v2.1.218). Doc: [docs/09-skills.md](./docs/09-skills.md#912-annunci-e-changelog-rilevanti), [docs/19-changelog.md](./docs/19-changelog.md).
+- **CLI v2.1.217** (21 lug): tetto di default a 20 subagent concorrenti per sessione, autocomplete emoji shortcode (`:heart:` → ❤️), fix memory leak negli output tool MCP, fix handshake mTLS/OAuth aziendale ignorati. Fonte: [GitHub Releases v2.1.217](https://github.com/anthropics/claude-code/releases/tag/v2.1.217). Doc: [docs/08-subagents.md](./docs/08-subagents.md#84-spawn--interazione), [docs/19-changelog.md](./docs/19-changelog.md).
+- **Claude Security plugin per Claude Code (beta)**: nuovo plugin ufficiale scansiona vulnerabilita' nei cambi di codice prima del commit o sull'intera codebase, distinto dal plugin `security-guidance` gia' disponibile da maggio. Fonte: [Claude blog](https://claude.com/blog/claude-security-public-beta) · [@claudeai](https://x.com/claudeai/status/2079990597973057691). Doc: [docs/11-plugins-marketplace.md](./docs/11-plugins-marketplace.md#1111-annunci-rilevanti).
+- **Limiti settimanali +50% prorogati fino al 19 agosto**: confermata l'estensione dell'aumento limiti gia' attivo per Pro, Max, Team e Enterprise a seat. Fonte: [@ClaudeDevs](https://x.com/ClaudeDevs/status/2078511173759324328).
 
 ---
 

--- a/docs/08-subagents.md
+++ b/docs/08-subagents.md
@@ -96,6 +96,8 @@ claude agents                  # Agent View (lista + stato sessioni)
 >
 > **Esecuzione comandi in background** (da v2.1.154): digitare `! <comando>` in Agent View esegue il comando shell in una nuova sessione background senza uscire dall'interfaccia — equivalente CLI: `claude --bg --exec '<comando>'`.
 
+> **2026-07-23 (auto-update)**: v2.1.217 (21 lug) introduce un tetto di default a 20 subagent concorrenti per sessione. Fonte: [GitHub Releases v2.1.217](https://github.com/anthropics/claude-code/releases/tag/v2.1.217). Vedi anche README "What's new today" del giorno.
+
 <sub>Aggiornato 2026-05-29 via daily what's new. Fonte: [GitHub Releases v2.1.154](https://github.com/anthropics/claude-code/releases/tag/v2.1.154).</sub>
 
 > **Cross-session messaging hardening** (da v2.1.166): i messaggi inoltrati via `SendMessage` da un'altra sessione Claude non portano piu' l'autorita' dell'utente. Le sessioni riceventi rifiutano le richieste di permesso inoltrate; in auto mode vengono bloccate direttamente. Questo significa che un agente che riceve un messaggio da un altro agente non puo' eseguire azioni che richiederebbero conferma utente, anche se l'agente mittente avrebbe quell'autorita'. Il comportamento era gia' documentato come best practice; ora e' applicato dall'harness. Fonte: [GitHub Releases v2.1.166](https://github.com/anthropics/claude-code/releases/tag/v2.1.166).

--- a/docs/09-skills.md
+++ b/docs/09-skills.md
@@ -277,6 +277,8 @@ Salva in `RELEASE_NOTES.md`.
 
 ## 9.12 Annunci e changelog rilevanti
 
+> **2026-07-23 (auto-update)**: `/code-review` (v2.1.218, 22 lug) gira ora come subagent in background invece di occupare la conversazione principale, mantenendo come target le invocazioni a comandi slash concatenati. Fonte: [GitHub Releases v2.1.218](https://github.com/anthropics/claude-code/releases/tag/v2.1.218). Vedi anche README "What's new today" del giorno.
+
 - **Hot reload Skills + custom agent support + invoke con `/`** (CC 2.1.0, dic 2025) — [@bcherny](https://x.com/bcherny/status/2009072293826453669)
 - **`/simplify` e `/batch`** (mar 2026) — [@bcherny](https://x.com/bcherny/status/2027534984534544489)
 - **Description cap 250 → 1,536 char** (v2.1.106, 13 apr 2026)

--- a/docs/11-plugins-marketplace.md
+++ b/docs/11-plugins-marketplace.md
@@ -277,6 +277,8 @@ LSP ufficiali: `typescript-lsp`, `pyright-lsp`, `rust-analyzer-lsp`, `gopls-lsp`
 
 ## 11.11 Annunci rilevanti
 
+> **2026-07-23 (auto-update)**: **Claude Security plugin per Claude Code (beta)** — nuovo plugin ufficiale che scansiona vulnerabilita' nei cambi di codice prima del commit o sull'intera codebase, distinto dal plugin `security-guidance` gia' disponibile da maggio 2026. Fonte: [Claude blog](https://claude.com/blog/claude-security-public-beta) · [@claudeai](https://x.com/claudeai/status/2079990597973057691). Vedi anche README "What's new today" del giorno.
+
 - **Customizability** (feb 2026): "hooks, plugins, LSPs, MCPs, skills, effort, custom agents, status lines, output styles" — [@bcherny](https://x.com/bcherny/status/2021699851499798911)
 - Hidden features Boris (mar 2026) — [@bcherny](https://x.com/bcherny/status/2038454336355999749)
 - Plugin executables sul `PATH` di Bash tool (Week 14, v2.1.94)

--- a/docs/19-changelog.md
+++ b/docs/19-changelog.md
@@ -3,7 +3,7 @@
 > 📍 [README](../README.md) → [Riferimenti](../README.md#riferimenti) → **19 Changelog**
 > 📚 Riferimento · 🟢 Beginner-friendly
 
-Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (18 luglio 2026, v2.1.214). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
+Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (22 luglio 2026, v2.1.218). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
 
 ## Cosa e' concettualmente
 
@@ -546,10 +546,14 @@ Vedi anche [@bcherny](https://x.com/bcherny/status/2047375800945783056).
 | 17 lug 2026 | **v2.1.212** | **`/fork` → sessione background + `/subtask`**: `/fork` copia ora l'intera conversazione in una nuova sessione background (riga propria in `claude agents`) invece di spawnare un subagent in-sessione — quel comportamento e' il nuovo `/subtask`. Aggiunti tetti di sicurezza per-sessione: WebSearch (default 200, `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION`) e subagent spawn (default 200, `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION`); chiamate MCP oltre 2 minuti passano automaticamente in background. `claude auto-mode reset` per ripristinare la config auto mode di default. `/resume` mostra un picker delle sessioni passate, incluse quelle cancellate. Fix: plan mode che eseguiva comandi Bash file-modifying senza prompt di permesso. |
 | 18 lug 2026 | **v2.1.214** | **Tool `EndConversation`**: nuovo tool primitivo che permette a Claude di terminare autonomamente conversazioni con utenti fortemente abusivi o tentativi di jailbreak ripetuti. Aggiunto heartbeat periodico di progresso per tool call di lunga durata e timestamp ISO `modified` nel frontmatter dei memory file. Fix di sicurezza: regole di permesso a singolo segmento tipo `Edit(src/**)` che auto-approvavano scritture in directory annidate ovunque nel repo (ora solo `<cwd>/dir`), bypass dei permission check su Windows PowerShell 5.1, comandi Bash oltre 10.000 caratteri che bypassavano il prompt di conferma. |
 | 19 lug 2026 | v2.1.215 | Claude non lancia piu' in autonomia le skill `/verify` e `/code-review` durante il normale flusso di lavoro — vanno invocate esplicitamente quando servono. |
+| 20 lug 2026 | v2.1.216 | **`sandbox.filesystem.disabled`**: nuova setting salta l'isolamento filesystem mantenendo attivo il controllo egress di rete. Fix: rallentamento nella normalizzazione messaggi su sessioni lunghe (costo quadratico coi turni), scadenza token OAuth in auto mode. |
+| 21 lug 2026 | **v2.1.217** | **Tetto di default a 20 subagent concorrenti per sessione**. Autocomplete emoji shortcode (es. `:heart:` → ❤️). Fix: memory leak negli output tool MCP, auto-update fallito su Windows, impostazioni mTLS/OAuth aziendali ignorate, cutoff dell'annuncio screen reader all'avvio. |
+| 22 lug 2026 | **v2.1.218** | **`/code-review` gira come subagent in background**: la review non riempie piu' la conversazione principale e mantiene le invocazioni a comandi slash concatenati come target. Annunci screen reader per cancellazioni di parola/riga in `--ax-screen-reader`. `claude agents --json`: sessioni in attesa di sandbox/MCP-input/managed-settings mostrano "Needs input" invece di "Working". Fix: path Windows con segmenti `\u`-prefixed corrotti in caratteri CJK negli input dei tool. |
 
 <sub>Aggiornato 2026-07-12 via daily what's new. Fonte: [GitHub Releases v2.1.205](https://github.com/anthropics/claude-code/releases/tag/v2.1.205) · [v2.1.206](https://github.com/anthropics/claude-code/releases/tag/v2.1.206) · [v2.1.207](https://github.com/anthropics/claude-code/releases/tag/v2.1.207) · [@ClaudeDevs](https://x.com/ClaudeDevs/status/2075635283211772279).</sub>
 <sub>Aggiornato 2026-07-18 via daily what's new. Fonte: [GitHub Releases v2.1.210](https://github.com/anthropics/claude-code/releases/tag/v2.1.210) · [v2.1.211](https://github.com/anthropics/claude-code/releases/tag/v2.1.211) · [v2.1.212](https://github.com/anthropics/claude-code/releases/tag/v2.1.212) · [v2.1.214](https://github.com/anthropics/claude-code/releases/tag/v2.1.214).</sub>
 <sub>Aggiornato 2026-07-19 via daily what's new. Fonte: [GitHub Releases v2.1.215](https://github.com/anthropics/claude-code/releases/tag/v2.1.215).</sub>
+<sub>Aggiornato 2026-07-23 via daily what's new. Fonte: [GitHub Releases v2.1.216](https://github.com/anthropics/claude-code/releases/tag/v2.1.216) · [v2.1.217](https://github.com/anthropics/claude-code/releases/tag/v2.1.217) · [v2.1.218](https://github.com/anthropics/claude-code/releases/tag/v2.1.218).</sub>
 
 ---
 

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -9,6 +9,12 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 **Politica di retention**: ultimi 30 giorni. Le entry piu' vecchie sono cancellate (per evitare crescita illimitata del file). La storia completa resta comunque tracciabile via `git log README.md`.
 
+## 2026-07-19
+
+- **`/verify` e `/code-review` non piu' auto-invocate** (v2.1.215, 19 lug): Claude non lancia piu' di propria iniziativa le skill `/verify` e `/code-review` a fine task — vanno invocate esplicitamente quando servono. Riduce le review "a sorpresa" non richieste dall'utente. Fonte: [GitHub Releases v2.1.215](https://github.com/anthropics/claude-code/releases/tag/v2.1.215). Doc: [docs/09-skills.md](./docs/09-skills.md), [docs/03-slash-commands.md](./docs/03-slash-commands.md), [docs/19-changelog.md](./docs/19-changelog.md).
+
+---
+
 ## 2026-07-18
 
 - **`/fork` → sessione background + `/subtask`** (v2.1.212, 17 lug): `/fork` non spawna piu' un subagent in-sessione ma copia l'intera conversazione in una nuova sessione background (riga separata in `claude agents`), lasciando libero il thread principale; il vecchio comportamento (subagent dentro la sessione corrente) e' ora `/subtask`. Stessa release: tetti di sicurezza default (200 WebSearch, 200 subagent spawn per sessione) e `/resume` con picker delle sessioni passate, incluse quelle cancellate. Fonte: [GitHub Releases v2.1.212](https://github.com/anthropics/claude-code/releases/tag/v2.1.212). Doc: [docs/08-subagents.md](./08-subagents.md), [docs/03-slash-commands.md](./03-slash-commands.md), [docs/19-changelog.md](./19-changelog.md).
@@ -186,13 +192,6 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 ## 2026-06-13
 
 > Nessuna novita' significativa nelle ultime 24 ore.
-
----
-
-## 2026-06-12
-
-- **Usage attribution per-skill/agent/plugin** (v2.1.174, 12 giu): il dialog "Account & usage" mostra ora breakdowns granulari per skill, agent, plugin e server MCP, oltre a cache misses e long context — utile per analizzare i costi nei workflow agentic complessi. Fonte: [GitHub Releases v2.1.174](https://github.com/anthropics/claude-code/releases/tag/v2.1.174). Doc: [docs/08-subagents.md](./docs/08-subagents.md), [docs/19-changelog.md](./docs/19-changelog.md).
-- **`enforceAvailableModels`** (v2.1.175, 12 giu): nuova opzione managed settings rende strict l'allowlist `availableModels` — il Default model e' ora vincolato dalla lista gestita e user/project settings non possono espandere i modelli consentiti dall'enterprise. Fonte: [GitHub Releases v2.1.175](https://github.com/anthropics/claude-code/releases/tag/v2.1.175). Doc: [docs/18-settings-auth.md](./docs/18-settings-auth.md), [docs/19-changelog.md](./docs/19-changelog.md).
 
 ---
 


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24-48h.

Generato dalla routine `whats-new-daily` ([automation README](../tree/main/automations/daily-whats-new)).

## Novita' coperte (4 voci)

- **CLI v2.1.218** (22 lug) — `/code-review` come subagent in background, fix path Windows, agent view "Needs input"
- **CLI v2.1.217** (21 lug) — tetto 20 subagent concorrenti, autocomplete emoji, fix mTLS/OAuth
- **Claude Security plugin per Claude Code (beta)** — nuovo plugin di scansione vulnerabilita'
- **Limiti settimanali +50% prorogati fino al 19 agosto**

## Nota sul gap

Il README mostrava ancora la sezione del 2026-07-19: sembra che la routine non sia girata (o non sia stata mergiata) per il 07-20/21/22. Ho recuperato le versioni v2.1.216-218 uscite in quella finestra invece di limitarmi strettamente alle ultime 24h, per non perdere traccia dei rilasci. Nessuna voce X-post specifica del giorno e' stata trovata oltre a quelle gia' citate (WebFetch diretto su x.com risulta bloccato con HTTP 402/403 dal proxy; usato WebSearch come da istruzioni).

Verificare:
- [ ] Sezione 'What's new today' nel README aggiornata
- [ ] Sezione precedente (2026-07-19) archiviata in docs/whats-new-archive.md, entry piu' vecchia (2026-06-12) rimossa per mantenere retention 30gg
- [ ] Callout aggiunti coerenti nei doc target (08-subagents.md, 09-skills.md, 11-plugins-marketplace.md, 19-changelog.md)
- [ ] Niente duplicati con ultime 7 entry archive

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9Fw3iB7EaojYSyCx25Yhn)_