### PR TITLE
What's new 2026-07-26

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,23 @@
 # Claude Code — Guida (5 maggio 2026)
 
 > Reference completa di Claude Code (CLI, IDE, Web, Desktop, SDK) curata da [Boosha AI](https://boosha.it).
-> Ultimo aggiornamento: **19 luglio 2026, 07:00 CEST**.
-> Versione CLI di riferimento: **v2.1.215** · Modello default **Sonnet 5** · Premium **Fable 5 / Opus 4.8 + xhigh** (Max plan).
+> Ultimo aggiornamento: **26 luglio 2026, 07:00 CEST**.
+> Versione CLI di riferimento: **v2.1.220** · Modello default **Sonnet 5** · Premium **Fable 5 / Opus 5 + xhigh** (Max plan).
 
 > 🆕 **Novita' aprile 2026 (F4)**: integrato il case study **Kora team Every** (compound engineering applicato), **filosofia vibe-to-agentic**, **workflow operativi storici** (worktree script, Friday refactor, bug investigation), **Conductor + Ralph community pattern**. Nuova [Quick Start 60 min](./docs/QUICKSTART.md) + 8 [template `.claude/` per persona](./examples/personas/).
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-07-19)
+## What's new today (2026-07-26)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-- **`/verify` e `/code-review` non piu' auto-invocate** (v2.1.215, 19 lug): Claude non lancia piu' di propria iniziativa le skill `/verify` e `/code-review` a fine task — vanno invocate esplicitamente quando servono. Riduce le review "a sorpresa" non richieste dall'utente. Fonte: [GitHub Releases v2.1.215](https://github.com/anthropics/claude-code/releases/tag/v2.1.215). Doc: [docs/09-skills.md](./docs/09-skills.md), [docs/03-slash-commands.md](./docs/03-slash-commands.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **Claude Opus 5** (24 lug): Anthropic rilascia il nuovo modello Opus-class — vicino alla frontier intelligence di Fable 5 a meta' prezzo ($5/$25 per Mtok, invariato rispetto a Opus 4.8), fast mode a ~2.5x, context 1M token di default. Diventa il modello di default su Claude Max. Fonte: [Anthropic news](https://www.anthropic.com/news/claude-opus-5) · [@claudeai](https://x.com/claudeai/status/2080699495453528290). Doc: [docs/05-fast-mode-1m-context.md](./docs/05-fast-mode-1m-context.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **CLI v2.1.219** (24 lug): Claude Code adotta Opus 5 come modello Opus di default, aggiunge la setting `sandbox.network.strictAllowlist` (nega host non allowlisted senza chiedere conferma), il nuovo hook `DirectoryAdded` (fire dopo `/add-dir`/`register_repo_root`) e porta i subagent annidati a profondita' 3 di default (era 1). Fonte: [GitHub Releases v2.1.219](https://github.com/anthropics/claude-code/releases/tag/v2.1.219). Doc: [docs/18-settings-auth.md](./docs/18-settings-auth.md), [docs/07-hooks.md](./docs/07-hooks.md), [docs/08-subagents.md](./docs/08-subagents.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **CLI v2.1.220** (25 lug): release di soli fix di stabilita' e affidabilita', nessuna feature nuova. Fonte: [GitHub Releases v2.1.220](https://github.com/anthropics/claude-code/releases/tag/v2.1.220). Doc: [docs/19-changelog.md](./docs/19-changelog.md).
+- **Thariq**: il team rimuove circa l'80% del system prompt storico di Claude Code per i modelli piu' recenti, cambiando approccio a come si scrivono system prompt, skill e CLAUDE.md per loro. Fonte: [@trq212](https://x.com/trq212/status/2080710971228918066). Doc: [docs/06-claude-md-memory.md](./docs/06-claude-md-memory.md).
+
+> _Nota: gap di una settimana dall'ultimo aggiornamento tracciato (19 lug); questa entry copre le novita' piu' recenti disponibili alle fonti (24-25 lug), non un giorno pieno di 24h._
 
 ---
 

--- a/docs/05-fast-mode-1m-context.md
+++ b/docs/05-fast-mode-1m-context.md
@@ -17,6 +17,8 @@ Feature legate ai modelli: il **fast mode** (Opus 4.8 di default, da v2.1.154), 
 
 ---
 
+> **2026-07-26 (auto-update)**: Anthropic rilascia **Claude Opus 5** (24 lug), disponibile subito in Claude Code — vicino alla frontier intelligence di Fable 5 a meta' prezzo ($5/$25 per Mtok), fast mode ~2.5x, 1M context di default. Con v2.1.219 diventa il modello Opus di default in Claude Code. Fonte: [Anthropic news](https://www.anthropic.com/news/claude-opus-5). Vedi anche README "What's new today" del giorno.
+
 ## 5.1 Fast mode (Opus 4.8 di default, da v2.1.154)
 
 ### Cosa fa

--- a/docs/06-claude-md-memory.md
+++ b/docs/06-claude-md-memory.md
@@ -17,6 +17,8 @@ Claude Code ha **due sistemi di memoria** complementari: CLAUDE.md (scritto da t
 
 ---
 
+> **2026-07-26 (auto-update)**: Thariq (team CC) racconta come il team abbia rimosso circa l'80% del system prompt storico di Claude Code per i modelli piu' recenti, cambiando approccio a scrittura di system prompt, skill e CLAUDE.md. Fonte: [@trq212](https://x.com/trq212/status/2080710971228918066). Vedi anche README "What's new today" del giorno.
+
 ## 6.1 Confronto
 
 |  | CLAUDE.md | Auto-memory |

--- a/docs/07-hooks.md
+++ b/docs/07-hooks.md
@@ -19,6 +19,8 @@ Gli hook permettono di intercettare deterministicamente il lifecycle di Claude C
 
 ---
 
+> **2026-07-26 (auto-update)**: v2.1.219 (24 lug) aggiunge il nuovo hook **`DirectoryAdded`**, che fire dopo `/add-dir` o dopo il control request SDK `register_repo_root`. Fonte: [GitHub Releases v2.1.219](https://github.com/anthropics/claude-code/releases/tag/v2.1.219). Vedi anche README "What's new today" del giorno.
+
 ## 7.1 Eventi supportati (28+)
 
 | Evento | Quando fire | Bloccabile? |

--- a/docs/08-subagents.md
+++ b/docs/08-subagents.md
@@ -19,6 +19,8 @@ Subagent = AI assistant specializzato con context window proprio, system prompt 
 
 ---
 
+> **2026-07-26 (auto-update)**: v2.1.219 (24 lug) porta la profondita' di default per subagent annidati a **3** (era 1) — `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH=1` per disattivare la nesting. Fonte: [GitHub Releases v2.1.219](https://github.com/anthropics/claude-code/releases/tag/v2.1.219). Vedi anche README "What's new today" del giorno.
+
 ## 8.1 Dove vivono
 
 | Scope | Path | Applies to |

--- a/docs/18-settings-auth.md
+++ b/docs/18-settings-auth.md
@@ -17,6 +17,8 @@ Gerarchia settings, sintassi permessi, autenticazione (claude.ai, API key, Bedro
 
 ---
 
+> **2026-07-26 (auto-update)**: v2.1.219 (24 lug) introduce `sandbox.network.strictAllowlist`, nuova setting che nega ai comandi sandboxati l'accesso a host non allowlisted senza chiedere conferma all'utente. Fonte: [GitHub Releases v2.1.219](https://github.com/anthropics/claude-code/releases/tag/v2.1.219). Vedi anche README "What's new today" del giorno.
+
 ## 18.1 Settings precedence (top to bottom)
 
 1. **Managed** (cannot override): server-distributed, plist/registry, system `managed-settings.json`

--- a/docs/19-changelog.md
+++ b/docs/19-changelog.md
@@ -3,7 +3,7 @@
 > 📍 [README](../README.md) → [Riferimenti](../README.md#riferimenti) → **19 Changelog**
 > 📚 Riferimento · 🟢 Beginner-friendly
 
-Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (18 luglio 2026, v2.1.214). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
+Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (25 luglio 2026, v2.1.220). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
 
 ## Cosa e' concettualmente
 
@@ -546,10 +546,14 @@ Vedi anche [@bcherny](https://x.com/bcherny/status/2047375800945783056).
 | 17 lug 2026 | **v2.1.212** | **`/fork` → sessione background + `/subtask`**: `/fork` copia ora l'intera conversazione in una nuova sessione background (riga propria in `claude agents`) invece di spawnare un subagent in-sessione — quel comportamento e' il nuovo `/subtask`. Aggiunti tetti di sicurezza per-sessione: WebSearch (default 200, `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION`) e subagent spawn (default 200, `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION`); chiamate MCP oltre 2 minuti passano automaticamente in background. `claude auto-mode reset` per ripristinare la config auto mode di default. `/resume` mostra un picker delle sessioni passate, incluse quelle cancellate. Fix: plan mode che eseguiva comandi Bash file-modifying senza prompt di permesso. |
 | 18 lug 2026 | **v2.1.214** | **Tool `EndConversation`**: nuovo tool primitivo che permette a Claude di terminare autonomamente conversazioni con utenti fortemente abusivi o tentativi di jailbreak ripetuti. Aggiunto heartbeat periodico di progresso per tool call di lunga durata e timestamp ISO `modified` nel frontmatter dei memory file. Fix di sicurezza: regole di permesso a singolo segmento tipo `Edit(src/**)` che auto-approvavano scritture in directory annidate ovunque nel repo (ora solo `<cwd>/dir`), bypass dei permission check su Windows PowerShell 5.1, comandi Bash oltre 10.000 caratteri che bypassavano il prompt di conferma. |
 | 19 lug 2026 | v2.1.215 | Claude non lancia piu' in autonomia le skill `/verify` e `/code-review` durante il normale flusso di lavoro — vanno invocate esplicitamente quando servono. |
+| 22 lug 2026 | v2.1.218 | `/code-review` gira ora come background subagent (non riempie piu' la conversazione principale). Miglioramenti screen reader, fix path Windows, fix transcript dopo errori API. |
+| 24 lug 2026 | **v2.1.219** | **Claude Opus 5 come Opus di default** in Claude Code (1M context, fast mode $10/$50 per Mtok). Nuova setting `sandbox.network.strictAllowlist` (nega host non allowlisted senza chiedere conferma ai comandi sandboxati). Nuovo hook `DirectoryAdded` (fire dopo `/add-dir` o SDK `register_repo_root`). Subagent annidati fino a profondita' 3 di default (era 1; `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH=1` per disattivare). `--forward-subagent-text` esteso ai subagent annidati in stream-json. Fix: `claude -p` che perdeva risposte su errori API mid-stream, label errata "Requires usage credits" sulla riga Fable, display del picker `/model` per Opus, copy-on-select in GNU screen, stato fast-mode stale in Remote Control, corruzione path Windows con segmenti `\u`-prefixed. |
+| 25 lug 2026 | v2.1.220 | Solo fix di stabilita' e affidabilita', nessuna feature nuova. |
 
 <sub>Aggiornato 2026-07-12 via daily what's new. Fonte: [GitHub Releases v2.1.205](https://github.com/anthropics/claude-code/releases/tag/v2.1.205) · [v2.1.206](https://github.com/anthropics/claude-code/releases/tag/v2.1.206) · [v2.1.207](https://github.com/anthropics/claude-code/releases/tag/v2.1.207) · [@ClaudeDevs](https://x.com/ClaudeDevs/status/2075635283211772279).</sub>
 <sub>Aggiornato 2026-07-18 via daily what's new. Fonte: [GitHub Releases v2.1.210](https://github.com/anthropics/claude-code/releases/tag/v2.1.210) · [v2.1.211](https://github.com/anthropics/claude-code/releases/tag/v2.1.211) · [v2.1.212](https://github.com/anthropics/claude-code/releases/tag/v2.1.212) · [v2.1.214](https://github.com/anthropics/claude-code/releases/tag/v2.1.214).</sub>
 <sub>Aggiornato 2026-07-19 via daily what's new. Fonte: [GitHub Releases v2.1.215](https://github.com/anthropics/claude-code/releases/tag/v2.1.215).</sub>
+<sub>Aggiornato 2026-07-26 via daily what's new. Fonte: [Anthropic news](https://www.anthropic.com/news/claude-opus-5) · [GitHub Releases v2.1.218](https://github.com/anthropics/claude-code/releases/tag/v2.1.218) · [v2.1.219](https://github.com/anthropics/claude-code/releases/tag/v2.1.219) · [v2.1.220](https://github.com/anthropics/claude-code/releases/tag/v2.1.220) · [@trq212](https://x.com/trq212/status/2080710971228918066).</sub>
 
 ---
 

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -9,6 +9,12 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 **Politica di retention**: ultimi 30 giorni. Le entry piu' vecchie sono cancellate (per evitare crescita illimitata del file). La storia completa resta comunque tracciabile via `git log README.md`.
 
+## 2026-07-19
+
+- **`/verify` e `/code-review` non piu' auto-invocate** (v2.1.215, 19 lug): Claude non lancia piu' di propria iniziativa le skill `/verify` e `/code-review` a fine task — vanno invocate esplicitamente quando servono. Riduce le review "a sorpresa" non richieste dall'utente. Fonte: [GitHub Releases v2.1.215](https://github.com/anthropics/claude-code/releases/tag/v2.1.215). Doc: [docs/09-skills.md](./09-skills.md), [docs/03-slash-commands.md](./03-slash-commands.md), [docs/19-changelog.md](./19-changelog.md).
+
+---
+
 ## 2026-07-18
 
 - **`/fork` → sessione background + `/subtask`** (v2.1.212, 17 lug): `/fork` non spawna piu' un subagent in-sessione ma copia l'intera conversazione in una nuova sessione background (riga separata in `claude agents`), lasciando libero il thread principale; il vecchio comportamento (subagent dentro la sessione corrente) e' ora `/subtask`. Stessa release: tetti di sicurezza default (200 WebSearch, 200 subagent spawn per sessione) e `/resume` con picker delle sessioni passate, incluse quelle cancellate. Fonte: [GitHub Releases v2.1.212](https://github.com/anthropics/claude-code/releases/tag/v2.1.212). Doc: [docs/08-subagents.md](./08-subagents.md), [docs/03-slash-commands.md](./03-slash-commands.md), [docs/19-changelog.md](./19-changelog.md).
@@ -186,13 +192,6 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 ## 2026-06-13
 
 > Nessuna novita' significativa nelle ultime 24 ore.
-
----
-
-## 2026-06-12
-
-- **Usage attribution per-skill/agent/plugin** (v2.1.174, 12 giu): il dialog "Account & usage" mostra ora breakdowns granulari per skill, agent, plugin e server MCP, oltre a cache misses e long context — utile per analizzare i costi nei workflow agentic complessi. Fonte: [GitHub Releases v2.1.174](https://github.com/anthropics/claude-code/releases/tag/v2.1.174). Doc: [docs/08-subagents.md](./docs/08-subagents.md), [docs/19-changelog.md](./docs/19-changelog.md).
-- **`enforceAvailableModels`** (v2.1.175, 12 giu): nuova opzione managed settings rende strict l'allowlist `availableModels` — il Default model e' ora vincolato dalla lista gestita e user/project settings non possono espandere i modelli consentiti dall'enterprise. Fonte: [GitHub Releases v2.1.175](https://github.com/anthropics/claude-code/releases/tag/v2.1.175). Doc: [docs/18-settings-auth.md](./docs/18-settings-auth.md), [docs/19-changelog.md](./docs/19-changelog.md).
 
 ---
 


### PR DESCRIPTION
Aggiornamento automatico daily "what's new" dalle ultime 24-48h.

Generato dalla routine `whats-new-daily` ([automation README](../tree/main/automations/daily-whats-new)).

## Novita' coperte (4 voci)

- **Claude Opus 5** (24 lug): nuovo modello Opus-class, vicino alla frontier intelligence di Fable 5 a meta' prezzo. Fonte: [Anthropic news](https://www.anthropic.com/news/claude-opus-5) · [@claudeai](https://x.com/claudeai/status/2080699495453528290).
- **CLI v2.1.219** (24 lug): Opus 5 come Opus di default in Claude Code, `sandbox.network.strictAllowlist`, hook `DirectoryAdded`, subagent annidati a profondita' 3. Fonte: [GitHub Releases v2.1.219](https://github.com/anthropics/claude-code/releases/tag/v2.1.219).
- **CLI v2.1.220** (25 lug): solo fix di stabilita'. Fonte: [GitHub Releases v2.1.220](https://github.com/anthropics/claude-code/releases/tag/v2.1.220).
- **Thariq**: rimozione ~80% del system prompt storico per i modelli piu' recenti. Fonte: [@trq212](https://x.com/trq212/status/2080710971228918066).

## Verificare

- [ ] Sezione "What's new today" nel README aggiornata
- [ ] Sezione precedente (19 lug) archiviata in docs/whats-new-archive.md
- [ ] Callout aggiunti coerenti con i doc target (05, 06, 07, 08, 18, 19)
- [ ] Niente duplicati con ultime 7 entry archive

## Nota sulla finestra temporale

L'ultimo aggiornamento tracciato su `main` risale al 19 luglio (gap di una settimana: risultano gia' aperte, non mergiate, le PR "What's new" dei giorni 07-20 → 07-25). Questa run copre quindi le novita' piu' recenti disponibili alle fonti (24-25 lug) invece di una finestra rigida di 24h, per non perdere il rilascio di Opus 5 e la v2.1.219/220.

## Branch

Nota: questa sessione e' assegnata al branch `claude/peaceful-volta-vk9ou4` (non `whats-new/2026-07-26` come da template originale della routine) per rispettare il vincolo di sessione "non pushare su branch diversi da quello designato".

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLUQXhv6TB3up1CEf7nm4k)_