### PR TITLE
What's new 2026-07-28

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-07-26)
+## What's new today (2026-07-28)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-- **Claude Opus 5** (v2.1.219, 24 lug): nuovo modello Opus, si avvicina a Fable 5 su molti benchmark a meta' del prezzo (stesso pricing di Opus 4.8, $5/$25 per MTok standard). Diventa il modello premium di default su Max e il piu' forte disponibile su Pro; effort toggle low/medium/high per bilanciare costo e capacita', 1M context nativo, modello meno "prompt-injectable" ad oggi. Sostituisce Opus 4.7 in fast mode (`/fast` ora copre Opus 5 e Opus 4.8). Fonte: [Anthropic news](https://www.anthropic.com/news/claude-opus-5) · [GitHub Releases v2.1.219](https://github.com/anthropics/claude-code/releases/tag/v2.1.219). Doc: [docs/01-snapshot.md](./docs/01-snapshot.md), [docs/05-fast-mode-1m-context.md](./docs/05-fast-mode-1m-context.md), [docs/19-changelog.md](./docs/19-changelog.md).
+> Nessuna novita' significativa nelle ultime 24 ore. Prossimo aggiornamento domani 07:00.
 
 ---
 

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -9,6 +9,12 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 **Politica di retention**: ultimi 30 giorni. Le entry piu' vecchie sono cancellate (per evitare crescita illimitata del file). La storia completa resta comunque tracciabile via `git log README.md`.
 
+## 2026-07-26
+
+- **Claude Opus 5** (v2.1.219, 24 lug): nuovo modello Opus, si avvicina a Fable 5 su molti benchmark a meta' del prezzo (stesso pricing di Opus 4.8, $5/$25 per MTok standard). Diventa il modello premium di default su Max e il piu' forte disponibile su Pro; effort toggle low/medium/high per bilanciare costo e capacita', 1M context nativo, modello meno "prompt-injectable" ad oggi. Sostituisce Opus 4.7 in fast mode (`/fast` ora copre Opus 5 e Opus 4.8). Fonte: [Anthropic news](https://www.anthropic.com/news/claude-opus-5) · [GitHub Releases v2.1.219](https://github.com/anthropics/claude-code/releases/tag/v2.1.219). Doc: [docs/01-snapshot.md](./01-snapshot.md), [docs/05-fast-mode-1m-context.md](./05-fast-mode-1m-context.md), [docs/19-changelog.md](./19-changelog.md).
+
+---
+
 ## 2026-07-19
 
 - **`/verify` e `/code-review` non piu' auto-invocate** (v2.1.215, 19 lug): Claude non lancia piu' di propria iniziativa le skill `/verify` e `/code-review` a fine task — vanno invocate esplicitamente quando servono. Riduce le review "a sorpresa" non richieste dall'utente. Fonte: [GitHub Releases v2.1.215](https://github.com/anthropics/claude-code/releases/tag/v2.1.215). Doc: [docs/09-skills.md](./09-skills.md), [docs/03-slash-commands.md](./03-slash-commands.md), [docs/19-changelog.md](./19-changelog.md).
@@ -184,12 +190,6 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 ---
 
 ## 2026-06-14
-
-> Nessuna novita' significativa nelle ultime 24 ore.
-
----
-
-## 2026-06-13
 
 > Nessuna novita' significativa nelle ultime 24 ore.
 


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily` ([automation README](../tree/main/automations/daily-whats-new)).

**Esito ricerca**: nessuna novita' Claude Code significativa rilevata nelle ultime 24 ore (27-28 luglio 2026). Verificate le fonti: changelog ufficiale, GitHub releases, Anthropic news/blog, `code.claude.com/docs/en/whats-new` (weekly digest fermo a Week 29, 13-17 lug), e ricerca su post recenti dei principali account team Anthropic (Boris Cherny, Cat Wu, Noah Zweben, Thariq, @claudeai, @ClaudeDevs). Gli item piu' recenti trovati (Opus 5, riduzione 80% system prompt, Cowork/Government beta) sono tutti antecedenti alla finestra delle 24h e gia' documentati nel repo.

Verificare:
- [x] Sezione 'What's new today' nel README aggiornata (2026-07-28, nessuna novita')
- [x] Sezione precedente (2026-07-26, Opus 5) archiviata in docs/whats-new-archive.md
- [ ] Callout aggiunti coerenti con i doc target — n/a, nessuna voce da callout oggi
- [x] Niente duplicati con ultime 7 entry archive

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_015x1yLxSVV9Cr1XM98kptUa)_