### PR TITLE
What's new 2026-07-30

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-07-29)
+## What's new today (2026-07-30)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-- **Spec MCP 2026-07-28**: il Model Context Protocol passa a un core stateless (niente piu' `Mcp-Session-Id`, ogni request puo' essere gestita da qualsiasi istanza server), con OAuth/OIDC rafforzati ed extension versionate per Apps e Tasks — il maggior aggiornamento del protocollo dal lancio. Supporto in rollout sui prodotti Claude, incluso Claude Code. Fonte: [Anthropic blog](https://claude.com/blog/bringing-mcp-2026-07-28-to-claude) · [@ClaudeDevs](https://x.com/ClaudeDevs/status/2082164248697069935). Doc: [docs/10-mcp.md](./docs/10-mcp.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **Interruzione globale ~3h**: Anthropic segnala errori elevati ("529 Overloaded") su Claude.ai, API e Claude Code dalle 19:49 alle 22:36 UTC del 29 luglio; servizio pienamente ripristinato, causa non dettagliata pubblicamente. Nessuna nuova release CLI oltre v2.1.220 nelle ultime 24 ore. Fonte: [status.claude.com](https://status.claude.com/).
 
 ---
 

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -9,6 +9,12 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 **Politica di retention**: ultimi 30 giorni. Le entry piu' vecchie sono cancellate (per evitare crescita illimitata del file). La storia completa resta comunque tracciabile via `git log README.md`.
 
+## 2026-07-29
+
+- **Spec MCP 2026-07-28**: il Model Context Protocol passa a un core stateless (niente piu' `Mcp-Session-Id`, ogni request puo' essere gestita da qualsiasi istanza server), con OAuth/OIDC rafforzati ed extension versionate per Apps e Tasks — il maggior aggiornamento del protocollo dal lancio. Supporto in rollout sui prodotti Claude, incluso Claude Code. Fonte: [Anthropic blog](https://claude.com/blog/bringing-mcp-2026-07-28-to-claude) · [@ClaudeDevs](https://x.com/ClaudeDevs/status/2082164248697069935). Doc: [docs/10-mcp.md](./10-mcp.md), [docs/19-changelog.md](./19-changelog.md).
+
+---
+
 ## 2026-07-28
 
 > Nessuna novita' significativa nelle ultime 24 ore.
@@ -192,12 +198,6 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 ## 2026-06-15
 
 - **Credito programmazione attivo da oggi** (15 giu 2026): i crediti mensili dedicati per uso programmatico entrano in vigore — `claude -p`, Agent SDK, GitHub Actions e app terze parti basate sull'SDK escono dal pool interattivo e attingono a un budget separato ($20 Pro · $100 Max 5x/Team per seat · $200 Max 20x/Enterprise per seat). Il credito va reclamato, si azzera con il ciclo di fatturazione e non e' cumulabile. Fonte: [@ClaudeDevs](https://x.com/ClaudeDevs/status/2054610152817619388). Doc: [docs/16-headless-agent-sdk.md](./docs/16-headless-agent-sdk.md#crediti-mensili-per-uso-programmatico-attivi-dal-15-giu-2026).
-
----
-
-## 2026-06-14
-
-> Nessuna novita' significativa nelle ultime 24 ore.
 
 ---
 


### PR DESCRIPTION
Aggiornamento automatico daily "what's new" dalle ultime 24h.

Generato dalla routine `whats-new-daily`.

## Sintesi ricerca (ultime 24h)
Nessuna nuova release CLI (ultima resta v2.1.220, 24-25 lug) ne' annuncio prodotto/feature Claude Code confermato nelle ultime 24 ore su changelog ufficiale, GitHub releases, blog Anthropic o post X dei team member monitorati (Boris Cherny, Cat Wu, Noah Zweben, Thariq, @claudeai, @ClaudeDevs, @alistaiir, @ClaudeCodeLog) datati oggi 30 luglio.

Unico evento rilevante e verificato: interruzione globale ~3h (errori "529 Overloaded" su Claude.ai, API e Claude Code) dalle 19:49 alle 22:36 UTC del 29 luglio, poi rientrata. Fonte: [status.claude.com](https://status.claude.com/).

## Verificare
- [x] Sezione "What's new today" nel README aggiornata (2026-07-30)
- [x] Sezione precedente (2026-07-29, spec MCP) archiviata in docs/whats-new-archive.md, retention 30 giorni rispettata (rimossa entry piu' vecchia 2026-06-14)
- [ ] Callout nei doc target: nessuno aggiunto — la voce di oggi non ha un capitolo target chiaro (nota operativa su status del servizio, non una feature Claude Code)
- [x] Niente duplicati con ultime 7 entry archive (controllate prima di scrivere)

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVikZgQwfXrocup9uBGftV)_