### PR TITLE
What's new 2026-08-03

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-08-02)
+## What's new today (2026-08-03)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -9,6 +9,12 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 **Politica di retention**: ultimi 30 giorni. Le entry piu' vecchie sono cancellate (per evitare crescita illimitata del file). La storia completa resta comunque tracciabile via `git log README.md`.
 
+## 2026-08-02
+
+> Nessuna novita' significativa nelle ultime 24 ore.
+
+---
+
 ## 2026-08-01
 
 > Nessuna novita' significativa nelle ultime 24 ore.
@@ -191,13 +197,6 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 ## 2026-06-17
 
 > Nessuna novita' significativa nelle ultime 24 ore.
-
----
-
-## 2026-06-16
-
-- **`Tool(param:value)` nelle permission rules** (v2.1.178, 15 giu): le regole `allow`/`deny` in `settings.json` supportano ora la sintassi `Tool(param:value)` per filtrare in base ai parametri del tool — ad esempio `Agent(model:opus)` in `deny` blocca qualsiasi sub-agente che usa Opus, con supporto wildcard `*`. Fonte: [GitHub Releases v2.1.178](https://github.com/anthropics/claude-code/releases/tag/v2.1.178). Doc: [docs/18-settings-auth.md](./docs/18-settings-auth.md#183-permission-rule-syntax), [docs/19-changelog.md](./docs/19-changelog.md).
-- **Nested `.claude/` directory precedence** (v2.1.178, 15 giu): skill, agenti, workflow e output-style nella directory `.claude/` piu' vicina alla working directory ora prevalgono su quelli di livello superiore; in caso di clash di nome, la skill annidata e' disponibile come `<dir>:<name>` — entrambe restano accessibili. I workflow salvati a livello progetto puntano ora alla `.claude/workflows/` piu' vicina. Fonte: [GitHub Releases v2.1.178](https://github.com/anthropics/claude-code/releases/tag/v2.1.178). Doc: [docs/09-skills.md](./docs/09-skills.md#96-auto-discovery-e-nested), [docs/19-changelog.md](./docs/19-changelog.md).
 
 ---
 


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily`.

**Esito ricerca**: nessuna novita' significativa rilevata nelle ultime 24 ore. Verificati: changelog ufficiale ([code.claude.com/docs/en/changelog](https://code.claude.com/docs/en/changelog)), [GitHub Releases](https://github.com/anthropics/claude-code/releases) (ultima resta v2.1.220, 25 luglio), CHANGELOG.md del repo, Anthropic news/blog, post X del team (@bcherny, @_catwu, @noahzweben, @trq212, @claudeai, @ClaudeDevs, @alistaiir, @ClaudeCodeLog). Nessun elemento datato 2-3 agosto 2026 rilevante per Claude Code.

Verificare:
- [x] Sezione 'What's new today' nel README aggiornata (2026-08-03, nessuna novita')
- [x] Sezione precedente (2026-08-02) archiviata in docs/whats-new-archive.md
- [x] Nessun callout aggiunto (nessuna novita' concreta da collegare a doc target)
- [x] Niente duplicati con ultime 7 entry archive
- [x] Retention archivio a 30 giornate (rimossa la giornata piu' vecchia, 2026-06-16)

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_018axoC2wzsdJmGKnyYCsveZ)_