### PR TITLE
What's new 2026-08-11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Claude Code — Guida (5 maggio 2026)
 
 > Reference completa di Claude Code (CLI, IDE, Web, Desktop, SDK) curata da [Boosha AI](https://boosha.it).
-> Ultimo aggiornamento: **10 agosto 2026, 07:00 CEST**.
-> Versione CLI di riferimento: **v2.1.226** · Modello default **Sonnet 5** · Premium **Fable 5 / Opus 5** (Max plan; Opus 4.8 rimane disponibile via `/model`).
+> Ultimo aggiornamento: **11 agosto 2026, 07:00 CEST**.
+> Versione CLI di riferimento: **v2.1.227** · Modello default **Sonnet 5** · Premium **Fable 5 / Opus 5** (Max plan; Opus 4.8 rimane disponibile via `/model`).
 
 > 🆕 **Novita' aprile 2026 (F4)**: integrato il case study **Kora team Every** (compound engineering applicato), **filosofia vibe-to-agentic**, **workflow operativi storici** (worktree script, Friday refactor, bug investigation), **Conductor + Ralph community pattern**. Nuova [Quick Start 60 min](./docs/QUICKSTART.md) + 8 [template `.claude/` per persona](./examples/personas/).
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-08-10)
+## What's new today (2026-08-11)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-- **Auto mode diventa default per Pro, Max e Team** (annuncio 9 ago, effettivo dal 14 ago): le nuove sessioni su questi piani partiranno in auto mode invece che in `manual` — il classifier ha bloccato l'89% delle azioni pericolose nei test interni contro il 13,6% della revisione manuale (1.053 tester paganti). Enterprise, API e i provider cloud (Bedrock, Vertex, Foundry) restano opt-in per ora. Fonte: [Anthropic blog](https://claude.com/blog/auto-mode-default-in-claude-code) · [@ClaudeDevs](https://x.com/ClaudeDevs/status/2085794862608318627) · [docs ufficiale](https://code.claude.com/docs/en/auto-mode-config). Doc: [docs/04-modalita-permessi.md](./docs/04-modalita-permessi.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **CLI v2.1.227** (10 ago): fix del prompt di upgrade Fable mostrato erroneamente a utenti Max con token di login scaduto, del fallimento di ogni comando Bash sotto `claude-code-action` con `allowed_non_write_users` su runner GitHub-hosted, e di `/tui` che ripristinava conversazioni riavvolte prima del primo messaggio. Migliora il menu slash-command (evidenzia solo la riga selezionata, match in grassetto, glifi emoji/accentati preservati) e riduce gli stall dell'event loop su suggerimenti file-not-found e controlli dimensione at-mention. Fonte: [GitHub Releases v2.1.227](https://github.com/anthropics/claude-code/releases/tag/v2.1.227). Vedi [docs/19 § Tabella versioni](./docs/19-changelog.md).
 
 ---
 

--- a/docs/19-changelog.md
+++ b/docs/19-changelog.md
@@ -3,7 +3,7 @@
 > 📍 [README](../README.md) → [Riferimenti](../README.md#riferimenti) → **19 Changelog**
 > 📚 Riferimento · 🟢 Beginner-friendly
 
-Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (8 agosto 2026, v2.1.226). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
+Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (10 agosto 2026, v2.1.227). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
 
 ## Cosa e' concettualmente
 
@@ -559,7 +559,9 @@ Vedi anche [@bcherny](https://x.com/bcherny/status/2047375800945783056).
 | 8 ago 2026 | v2.1.225 | Warning di spesa gateway con dettaglio limite/reset. Prompt di trust workspace per `claude agents` su cartelle non fidate. Fix: token 401 transitori su replacement OAuth, MCP OAuth su macOS dopo timeout keychain, cronologia Remote Control rotta dopo compaction, messaggi cross-session rimasti in coda senza scadenza in sessioni headless. |
 | 8 ago 2026 | v2.1.226 | Bug fix e miglioramenti di affidabilita'. |
 | 9 ago 2026 | — | **Auto mode diventa default** per Pro, Max e Team dal 14 agosto: sostituisce `manual` come permission mode di partenza per le nuove sessioni. Il classifier ha bloccato l'89% delle azioni pericolose in test interni (1.053 tester paganti) contro il 13,6% della revisione manuale. Enterprise, API e provider cloud (Bedrock/Vertex/Foundry) restano opt-in — vedi [4.3](./04-modalita-permessi.md#43-auto-mode-da-v2183-default-promaxteam-da-14-ago-2026). |
+| 10 ago 2026 | v2.1.227 | Fix: prompt di upgrade Fable mostrato erroneamente a utenti Max con token di login scaduto, ogni comando Bash fallito sotto `claude-code-action` con `allowed_non_write_users` su runner GitHub-hosted, `/tui` che ripristinava conversazioni riavvolte prima del primo messaggio. Menu slash-command: evidenzia solo la riga selezionata, match in grassetto, glifi emoji/accentati preservati. Performance: meno stall dell'event loop su suggerimenti file-not-found e controlli dimensione at-mention. |
 
+<sub>Aggiornato 2026-08-11 via daily what's new. Fonte: [GitHub Releases v2.1.227](https://github.com/anthropics/claude-code/releases/tag/v2.1.227).</sub>
 <sub>Aggiornato 2026-08-10 via daily what's new. Fonte: [Anthropic blog](https://claude.com/blog/auto-mode-default-in-claude-code) · [@ClaudeDevs](https://x.com/ClaudeDevs/status/2085794862608318627) · [code.claude.com/docs/en/auto-mode-config](https://code.claude.com/docs/en/auto-mode-config).</sub>
 <sub>Aggiornato 2026-08-08 via daily what's new. Fonte: [GitHub Releases v2.1.224](https://github.com/anthropics/claude-code/releases/tag/v2.1.224) · [v2.1.225](https://github.com/anthropics/claude-code/releases/tag/v2.1.225) · [v2.1.226](https://github.com/anthropics/claude-code/releases/tag/v2.1.226) · [Anthropic blog](https://claude.com/blog/run-claude-code-sessions-on-your-own-compute).</sub>
 <sub>Aggiornato 2026-08-06 via daily what's new. Fonte: [GitHub Releases v2.1.221](https://github.com/anthropics/claude-code/releases/tag/v2.1.221) · [v2.1.222](https://github.com/anthropics/claude-code/releases/tag/v2.1.222) · [v2.1.223](https://github.com/anthropics/claude-code/releases/tag/v2.1.223).</sub>

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -9,6 +9,12 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 **Politica di retention**: ultimi 30 giorni. Le entry piu' vecchie sono cancellate (per evitare crescita illimitata del file). La storia completa resta comunque tracciabile via `git log README.md`.
 
+## 2026-08-10
+
+- **Auto mode diventa default per Pro, Max e Team** (annuncio 9 ago, effettivo dal 14 ago): le nuove sessioni su questi piani partiranno in auto mode invece che in `manual` — il classifier ha bloccato l'89% delle azioni pericolose nei test interni contro il 13,6% della revisione manuale (1.053 tester paganti). Enterprise, API e i provider cloud (Bedrock, Vertex, Foundry) restano opt-in per ora. Fonte: [Anthropic blog](https://claude.com/blog/auto-mode-default-in-claude-code) · [@ClaudeDevs](https://x.com/ClaudeDevs/status/2085794862608318627) · [docs ufficiale](https://code.claude.com/docs/en/auto-mode-config). Doc: [docs/04-modalita-permessi.md](./docs/04-modalita-permessi.md), [docs/19-changelog.md](./docs/19-changelog.md).
+
+---
+
 ## 2026-08-08
 
 - **Ambienti self-hosted per Claude Code** (v2.1.224, 7 ago): beta pubblica di `claude self-hosted-runner` — le sessioni web/mobile/desktop possono girare sull'infrastruttura del team (fixed o on-demand) invece che su quella cloud Anthropic, per Team ed Enterprise. Fonte: [GitHub Releases v2.1.224](https://github.com/anthropics/claude-code/releases/tag/v2.1.224) · [Anthropic blog](https://claude.com/blog/run-claude-code-sessions-on-your-own-compute). Doc: [docs/13-routines-cloud.md](./13-routines-cloud.md), [docs/19-changelog.md](./19-changelog.md).
@@ -189,12 +195,6 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 ---
 
 ## 2026-06-21
-
-> Nessuna novita' significativa nelle ultime 24 ore.
-
----
-
-## 2026-06-20
 
 > Nessuna novita' significativa nelle ultime 24 ore.
 


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily` ([automation README](../tree/main/automations/daily-whats-new)).

## Novita' rilevata (1 voce)

- **CLI v2.1.227** (10 ago): fix su prompt Fable errato per utenti Max con token scaduto, Bash bloccato in `claude-code-action` con `allowed_non_write_users`, `/tui` su conversazioni riavvolte; migliora menu slash-command e performance. Fonte: [GitHub Releases v2.1.227](https://github.com/anthropics/claude-code/releases/tag/v2.1.227).

Nessun annuncio Anthropic blog, post X team, o feature rilevante individuata nelle ultime 24h oltre alla release patch.

Verificare:
- [x] Sezione 'What's new today' nel README aggiornata
- [x] Sezione precedente (2026-08-10) archiviata in docs/whats-new-archive.md
- [x] Entry versione aggiunta in docs/19-changelog.md (tabella 19.9)
- [ ] Callout: nessuno aggiunto — la release e' solo fix/perf, nessun capitolo target dedicato oltre al changelog
- [x] Niente duplicati con ultime 7 entry archive

Nota: ho trovato un backlog di ~58 PR "What's new" ancora aperte e non mergiate (dal 2026-07-15 al 2026-08-10) — potrebbe valere la pena rivederle/chiuderle in batch.

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_011EoF9DG2KnP4NNpzZTxDU6)_