### PR TITLE
What's new 2026-08-31

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-08-29)
+## What's new today (2026-08-31)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-- **Hook `PreModelSwitch`/`PostModelSwitch`** (v2.1.251, 28 ago): due nuovi eventi hook bloccano, confermano o annotano un cambio di modello a runtime (fallback auto mode, `/model`, switch programmatico); i `SessionStart` di tipo resume ricevono ora anche staleness della sessione e stima del costo di re-cache. Fonte: [GitHub Releases v2.1.251](https://github.com/anthropics/claude-code/releases/tag/v2.1.251). Doc: [docs/07-hooks.md](./docs/07-hooks.md), [docs/19-changelog.md](./docs/19-changelog.md).
+- **ClaudeDevs: limiti settimanali +25% permanente dal 14 settembre** (30 ago): dal 14 settembre i limiti settimanali standard salgono permanentemente del 25% (Pro/Max/Team/Enterprise a seat), sostituendo il boost temporaneo del 50% attivo dall'estate — di fatto -17% rispetto ai limiti gonfiati di oggi. Fonte: [@ClaudeDevs](https://x.com/ClaudeDevs/status/2093742321473065266). Vedi [docs/01 § 1.4 Pricing](./docs/01-snapshot.md), [docs/19-changelog.md](./docs/19-changelog.md).
 
-Il resto della release v2.1.251 (streaming live dei tool call subagent verso Remote Control, spend limit bar in `/usage`, metriche prompt-cache per-sessione in `/cost`, ampi fix di sicurezza sui tool file) resta sotto la soglia editoriale. Nessun annuncio Anthropic dedicato su Claude Code nelle ultime 24 ore.
+Nessuna nuova versione CLI dalle ultime 24 ore (ultima resta v2.1.251, 28 ago). Nessun altro annuncio Anthropic o post team dedicato su Claude Code nelle ultime 24 ore.
 
 ---
 

--- a/docs/01-snapshot.md
+++ b/docs/01-snapshot.md
@@ -70,6 +70,8 @@ Annunci recenti rilevanti:
 
 ## 1.4 Pricing (semplificato)
 
+> **2026-08-31 (auto-update)**: dal 14 settembre i limiti settimanali standard salgono permanentemente del 25% per Pro/Max/Team/Enterprise a seat, sostituendo il boost temporaneo del 50% attivo dall'estate (di fatto -17% rispetto a oggi). Fonte: [@ClaudeDevs](https://x.com/ClaudeDevs/status/2093742321473065266). Vedi anche README "What's new today" del giorno.
+
 | Plan | Cosa offre |
 |---|---|
 | Pro | Sonnet 4.6 + Opus 4.6, plan/auto mode, `/loop`, 5 routine scheduled/giorno — **limiti 5-ore raddoppiati**, no peak-hour limits (da 6 mag 2026) |

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -9,6 +9,14 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 **Politica di retention**: ultimi 30 giorni. Le entry piu' vecchie sono cancellate (per evitare crescita illimitata del file). La storia completa resta comunque tracciabile via `git log README.md`.
 
+## 2026-08-29
+
+- **Hook `PreModelSwitch`/`PostModelSwitch`** (v2.1.251, 28 ago): due nuovi eventi hook bloccano, confermano o annotano un cambio di modello a runtime (fallback auto mode, `/model`, switch programmatico); i `SessionStart` di tipo resume ricevono ora anche staleness della sessione e stima del costo di re-cache. Fonte: [GitHub Releases v2.1.251](https://github.com/anthropics/claude-code/releases/tag/v2.1.251). Doc: [docs/07-hooks.md](./docs/07-hooks.md), [docs/19-changelog.md](./docs/19-changelog.md).
+
+Il resto della release v2.1.251 (streaming live dei tool call subagent verso Remote Control, spend limit bar in `/usage`, metriche prompt-cache per-sessione in `/cost`, ampi fix di sicurezza sui tool file) resta sotto la soglia editoriale. Nessun annuncio Anthropic dedicato su Claude Code nelle ultime 24 ore.
+
+---
+
 ## 2026-08-28
 
 > Nessuna novita' significativa nelle ultime 24 ore. Le release piu' recenti (v2.1.247, v2.1.248, v2.1.250, 26-28 ago) restano sotto la soglia editoriale: tool `SendFeedback` per bozze di feedback da `/feedback`, `/claude-api cost-optimize` per profilare la spesa API, nuovo flag `--restricted` per sessioni lock-down (rimuove i tool che eseguono comandi/codice e `WebFetch`, rifiuta `bypassPermissions`, ignora i settings utente/progetto), cross-session messaging esteso a Bedrock/Vertex/Foundry, fix di sicurezza (`/ultrareview` non carica piu' file tipo `.env`/`.tfvars`/backup di credenziali). Nessun annuncio Anthropic rilevante su Claude Code nelle ultime 24 ore.
@@ -188,12 +196,6 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 ---
 
 ## 2026-06-29
-
-> Nessuna novita' significativa nelle ultime 24 ore.
-
----
-
-## 2026-06-28
 
 > Nessuna novita' significativa nelle ultime 24 ore.
 


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily` ([automation README](../tree/main/automations/daily-whats-new)).

## Novita' trovate

1 voce editoriale nelle ultime ~30h (nessuna nuova versione CLI dal 28 agosto, v2.1.251):

- **ClaudeDevs**: dal 14 settembre i limiti settimanali standard di Claude Code salgono permanentemente del 25% (Pro/Max/Team/Enterprise a seat), sostituendo il boost temporaneo del 50% attivo dall'estate — di fatto -17% rispetto ai limiti odierni. Fonte: [@ClaudeDevs](https://x.com/ClaudeDevs/status/2093742321473065266).

## Verificare

- [x] Sezione 'What's new today' nel README aggiornata (2026-08-31)
- [x] Sezione precedente (2026-08-29) archiviata in docs/whats-new-archive.md
- [x] Callout aggiunto in docs/01-snapshot.md § 1.4 Pricing, coerente con la voce
- [x] Niente duplicati con le ultime 7 entry dell'archive

## Note

- Ricerca coperta: GitHub Releases (nessuna release dopo v2.1.251, 28 ago), changelog e whats-new ufficiali (nessuna entry nuova), claude.com/blog (nessun post Claude Code nelle ultime 24h), post X dei principali account team (@bcherny, @_catwu, @noahzweben, @trq212, @claudeai, @ClaudeDevs, @alistaiir, @ClaudeCodeLog).
- `www.anthropic.com` e diversi aggregator di notizie sono risultati bloccati dal proxy di rete della sessione; le informazioni sull'annuncio ClaudeDevs sono state verificate incrociando piu' fonti secondarie (Notebookcheck, Bleeping Computer, ecc.) via WebSearch.
- Nota rilevante ma non inclusa nel TLDR (gia' nota, non e' una novita' delle ultime 24h): il pricing promozionale di Sonnet 5 ($2/$10 per MTok) termina oggi 31 agosto, standard $3/$15 dal 1 settembre.

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dxodbea2JfuMZLAeuYGz4N)_