### PR TITLE
What's new 2026-09-01

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,18 @@
 # Claude Code — Guida (5 maggio 2026)
 
 > Reference completa di Claude Code (CLI, IDE, Web, Desktop, SDK) curata da [Boosha AI](https://boosha.it).
-> Ultimo aggiornamento: **29 agosto 2026, 07:00 CEST**.
-> Versione CLI di riferimento: **v2.1.251** · Modello default **Sonnet 5** · Premium **Fable 5 / Opus 5** (Max plan; Opus 4.8 rimane disponibile via `/model`).
+> Ultimo aggiornamento: **1 settembre 2026, 07:00 CEST**.
+> Versione CLI di riferimento: **v2.1.252** · Modello default **Sonnet 5** · Premium **Fable 5 / Opus 5** (Max plan; Opus 4.8 rimane disponibile via `/model`).
 
 > 🆕 **Novita' aprile 2026 (F4)**: integrato il case study **Kora team Every** (compound engineering applicato), **filosofia vibe-to-agentic**, **workflow operativi storici** (worktree script, Friday refactor, bug investigation), **Conductor + Ralph community pattern**. Nuova [Quick Start 60 min](./docs/QUICKSTART.md) + 8 [template `.claude/` per persona](./examples/personas/).
 > 👉 **Nuovo a Claude Code?** Inizia da [docs/QUICKSTART.md](./docs/QUICKSTART.md) (60 min) o [README-NAVIGATION.md](./README-NAVIGATION.md) per il percorso adatto al tuo profilo.
 > 🤖 **Automazione daily**: ogni giorno alle 07:00 Europe/Rome una routine cloud aggiorna la sezione "What's new today" (vedi sotto). Setup: [`automations/daily-whats-new/`](./automations/daily-whats-new/).
 
-## What's new today (2026-08-29)
+## What's new today (2026-09-01)
 
 > _Aggiornamento automatico dalle 07:00 Europe/Rome. Vedi [archive](./docs/whats-new-archive.md) per i giorni precedenti._
 
-- **Hook `PreModelSwitch`/`PostModelSwitch`** (v2.1.251, 28 ago): due nuovi eventi hook bloccano, confermano o annotano un cambio di modello a runtime (fallback auto mode, `/model`, switch programmatico); i `SessionStart` di tipo resume ricevono ora anche staleness della sessione e stima del costo di re-cache. Fonte: [GitHub Releases v2.1.251](https://github.com/anthropics/claude-code/releases/tag/v2.1.251). Doc: [docs/07-hooks.md](./docs/07-hooks.md), [docs/19-changelog.md](./docs/19-changelog.md).
-
-Il resto della release v2.1.251 (streaming live dei tool call subagent verso Remote Control, spend limit bar in `/usage`, metriche prompt-cache per-sessione in `/cost`, ampi fix di sicurezza sui tool file) resta sotto la soglia editoriale. Nessun annuncio Anthropic dedicato su Claude Code nelle ultime 24 ore.
+> Nessuna novita' significativa nelle ultime 24 ore. L'unica release (v2.1.252, 31 ago) contiene solo fix (comandi Bash falliti su alcuni Mac, "always allow" non salvato senza `.claude/settings.local.json`, stalli di Remote Control su connessioni degradate, overflow del limite richieste API su output di errore molto voluminosi), sotto la soglia editoriale. Nessun annuncio Anthropic o post team dedicato su Claude Code nelle ultime 24 ore.
 
 ---
 

--- a/docs/19-changelog.md
+++ b/docs/19-changelog.md
@@ -3,7 +3,7 @@
 > 📍 [README](../README.md) → [Riferimenti](../README.md#riferimenti) → **19 Changelog**
 > 📚 Riferimento · 🟢 Beginner-friendly
 
-Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (28 agosto 2026, v2.1.251). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
+Cronologia completa di Claude Code dalla research preview (24 febbraio 2025, v0.2.0) all'ultima versione (31 agosto 2026, v2.1.252). 7 fasi storiche + tabella versione per versione + post-mortem aprile 2026.
 
 ## Cosa e' concettualmente
 
@@ -580,6 +580,9 @@ Vedi anche [@bcherny](https://x.com/bcherny/status/2047375800945783056).
 | 27-28 ago 2026 | **v2.1.248** | **Flag `--restricted`** (o `CLAUDE_CODE_RESTRICTED=1`): nuova modalita' lock-down che rimuove i tool built-in di esecuzione comandi/codice e `WebFetch` (salvo elenco esplicito in `--tools`), confina i tool file alla working directory, rifiuta `bypassPermissions` e ignora i settings utente/progetto/locali — pensata per sessioni CI o contesti non fidati. `experimental.cacheTtl` nel frontmatter agent per il TTL della prompt cache per-agente. Cross-session messaging (`SendMessage`/`ListAgents`) esteso a sessioni sulla stessa macchina su Bedrock, Vertex e Foundry. Fix sicurezza: `/ultrareview` non carica piu' su cloud file tipo `.env`/`.tfvars` non committati o backup/copie temporanee di credenziali (`key.pem.tmp`, `id_rsa.swo`). Fix: cache miss orario nelle sessioni lunghe dopo refresh OAuth, sessioni Desktop/Cowork cancellate dopo 30 giorni (nuovo `desktopSessionCleanupPeriodDays`). |
 | 28 ago 2026 | v2.1.250 | Bug fix e miglioramenti di affidabilita'. |
 | 28 ago 2026 | **v2.1.251** | **Hook `PreModelSwitch`/`PostModelSwitch`**: bloccano, confermano o annotano un cambio di modello a runtime — vedi [7.6](./07-hooks.md#premodelswitch--postmodelswitch-da-v21251). `SessionStart` di tipo resume riceve ora anche staleness della sessione e stima del costo di re-cache. Streaming live dei tool call di un subagent in foreground verso Remote Control. Spend limit bar in `/usage` e riga prompt-cache per-sessione in `/cost`. Ampi fix di sicurezza sui tool file (symlink post-permesso), path dei comandi plugin, path del Workflow tool e regole `Read(...)` su Glob/Grep. |
+| 31 ago 2026 | v2.1.252 | Fix: comandi Bash falliti su alcuni Mac ("task output swap refused"), "always allow" non salvato in progetti senza `.claude/settings.local.json`, stalli di sessioni Remote Control dopo tool completati su connessioni claude.ai degradate, notifiche task in background che superavano il limite dimensione richieste API su output di errore molto voluminosi. |
+
+<sub>Aggiornato 2026-09-01 via daily what's new. Fonte: [GitHub Releases v2.1.252](https://github.com/anthropics/claude-code/releases/tag/v2.1.252). Nessuna voce editoriale: solo bug fix, sotto soglia. Nessun annuncio Anthropic o post team dedicato nelle ultime 24 ore.</sub>
 
 <sub>Aggiornato 2026-08-29 via daily what's new. Fonte: [GitHub Releases v2.1.251](https://github.com/anthropics/claude-code/releases/tag/v2.1.251). Unica voce editoriale del giorno: i nuovi hook di model switch (feature di sistema, hook system). Il resto della release (streaming Remote Control, spend limit bar, metriche prompt-cache, fix di sicurezza) resta sotto soglia. Nessun annuncio Anthropic o post team dedicato nelle ultime 24 ore.</sub>
 

--- a/docs/whats-new-archive.md
+++ b/docs/whats-new-archive.md
@@ -9,6 +9,14 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 
 **Politica di retention**: ultimi 30 giorni. Le entry piu' vecchie sono cancellate (per evitare crescita illimitata del file). La storia completa resta comunque tracciabile via `git log README.md`.
 
+## 2026-08-29
+
+- **Hook `PreModelSwitch`/`PostModelSwitch`** (v2.1.251, 28 ago): due nuovi eventi hook bloccano, confermano o annotano un cambio di modello a runtime (fallback auto mode, `/model`, switch programmatico); i `SessionStart` di tipo resume ricevono ora anche staleness della sessione e stima del costo di re-cache. Fonte: [GitHub Releases v2.1.251](https://github.com/anthropics/claude-code/releases/tag/v2.1.251). Doc: [docs/07-hooks.md](./07-hooks.md), [docs/19-changelog.md](./19-changelog.md).
+
+Il resto della release v2.1.251 (streaming live dei tool call subagent verso Remote Control, spend limit bar in `/usage`, metriche prompt-cache per-sessione in `/cost`, ampi fix di sicurezza sui tool file) resta sotto la soglia editoriale. Nessun annuncio Anthropic dedicato su Claude Code nelle ultime 24 ore.
+
+---
+
 ## 2026-08-28
 
 > Nessuna novita' significativa nelle ultime 24 ore. Le release piu' recenti (v2.1.247, v2.1.248, v2.1.250, 26-28 ago) restano sotto la soglia editoriale: tool `SendFeedback` per bozze di feedback da `/feedback`, `/claude-api cost-optimize` per profilare la spesa API, nuovo flag `--restricted` per sessioni lock-down (rimuove i tool che eseguono comandi/codice e `WebFetch`, rifiuta `bypassPermissions`, ignora i settings utente/progetto), cross-session messaging esteso a Bedrock/Vertex/Foundry, fix di sicurezza (`/ultrareview` non carica piu' file tipo `.env`/`.tfvars`/backup di credenziali). Nessun annuncio Anthropic rilevante su Claude Code nelle ultime 24 ore.
@@ -188,12 +196,6 @@ Il README master mostra **solo l'aggiornamento del giorno corrente**. Quando ne 
 ---
 
 ## 2026-06-29
-
-> Nessuna novita' significativa nelle ultime 24 ore.
-
----
-
-## 2026-06-28
 
 > Nessuna novita' significativa nelle ultime 24 ore.
 


### PR DESCRIPTION
Aggiornamento automatico daily what's new dalle ultime 24h.

Generato dalla routine `whats-new-daily` ([automation README](../tree/main/automations/daily-whats-new)).

**Nota sul branch**: la routine originale chiede un branch dedicato `whats-new/2026-09-01`, ma le istruzioni operative di questa sessione assegnano in modo esplicito il branch `claude/peaceful-volta-mi3q15` per tutto lo sviluppo e vietano il push su branch diversi senza permesso esplicito. Ho quindi committato e pushato su `claude/peaceful-volta-mi3q15` invece di crearne uno nuovo.

## Sintesi ricerca (ultime 24h)

Nessuna novita' editoriale nelle ultime 24 ore. L'unica release pubblicata (**v2.1.252**, 31 agosto 2026) contiene solo bug fix:
- comandi Bash falliti su alcuni Mac ("task output swap refused")
- "always allow" non salvato in progetti senza `.claude/settings.local.json`
- stalli di sessioni Remote Control dopo tool completati su connessioni claude.ai degradate
- notifiche task in background che superavano il limite dimensione richieste API su output di errore molto voluminosi

Nessun annuncio Anthropic/blog dedicato a Claude Code, nessun post rilevante datato oggi dagli account team tracciati (@bcherny, @_catwu, @noahzweben, @trq212, @claudeai, @ClaudeDevs, @alistaiir, @ClaudeCodeLog) nelle fonti verificabili via WebSearch (fetch diretto a x.com non disponibile, aggirato con WebSearch come da istruzioni). Fetch di `www.anthropic.com/news` bloccato dal proxy di rete della sessione.

## Modifiche

- `README.md`: sezione "What's new today" aggiornata a 2026-09-01 (nessuna voce, sotto soglia editoriale), versione CLI di riferimento aggiornata a v2.1.252.
- `docs/whats-new-archive.md`: archiviata la sezione del 2026-08-29 in cima; rimossa l'entry piu' vecchia (2026-06-28) per mantenere la retention a 30 giorni.
- `docs/19-changelog.md`: aggiunta riga v2.1.252 in tabella versione-per-versione, aggiornata intestazione e aggiunta nota di addendum.

## Verificare

- [ ] Sezione 'What's new today' nel README aggiornata
- [ ] Sezione precedente archiviata in docs/whats-new-archive.md
- [ ] Nessun callout aggiunto (nessuna novita' con "Dove in repo" concreto oggi)
- [ ] Niente duplicati con ultime 7 entry archive

Auto-merge non attivo per default. Mergiare manualmente se OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMm2NxYcgdEnTEKCAJw2Ys)_